### PR TITLE
Fix header include and move TrayApp destructor out-of-line

### DIFF
--- a/src/NoHangUnit.cpp
+++ b/src/NoHangUnit.cpp
@@ -2,6 +2,7 @@
 #include "NoHangUnit.h"
 #include <QProcess>
 #include <QStringList>
+#include <QRegularExpression>
 
 static const char* kUnit = "nohang-desktop.service";
 

--- a/src/TrayApp.cpp
+++ b/src/TrayApp.cpp
@@ -13,6 +13,8 @@
 static constexpr int kPollMs = 5000;
 static constexpr int kCfgWatchMs = 3000;
 
+TrayApp::~TrayApp() = default;
+
 TrayApp::TrayApp(QObject* parent) : QObject(parent) {}
 
 void TrayApp::start() {

--- a/src/TrayApp.h
+++ b/src/TrayApp.h
@@ -22,6 +22,7 @@ class TrayApp : public QObject {
     Q_OBJECT
 public:
     explicit TrayApp(QObject* parent = nullptr);
+    ~TrayApp();  // out-of-line definition in the .cpp
     void start();
 
 private slots:


### PR DESCRIPTION
## Summary
- Include `<QRegularExpression>` in NoHangUnit.cpp
- Declare TrayApp's destructor in the header and define it out-of-line so `unique_ptr` sees complete types

## Testing
- ❌ `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug` (missing KF6StatusNotifierItem package)
- ⚠️ `sudo apt-get install -y libkf6statusnotifieritem-dev` (package not found)


------
https://chatgpt.com/codex/tasks/task_e_68b0e427b0f08330b9615b74d00133cd