### PR TITLE
Enable Qt automatic MOC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@
 cmake_minimum_required(VERSION 3.24)
 project(nohang-tray VERSION 0.1.0 LANGUAGES CXX)
 
+set(CMAKE_AUTOMOC ON)
+
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 


### PR DESCRIPTION
## Summary
- enable Qt's automatic MOC processing via `set(CMAKE_AUTOMOC ON)`

## Testing
- `cmake -S . -B build && cmake --build build -j` *(fails: Could NOT find XKB, Could NOT find KF6StatusNotifierItem)*
- `ctest --test-dir build --output-on-failure` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0ec2fdbf88330a0b21c14d3f36b78