### PR TITLE
Add NoHangConfig parsing tests and CI step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,9 @@ jobs:
       - name: Build
         run: cmake --build build -j
 
+      - name: Test
+        run: ctest --test-dir build --output-on-failure
+
       - uses: actions/upload-artifact@v4
         with:
           name: nohang-tray-debian

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,8 @@ project(nohang-tray VERSION 0.1.0 LANGUAGES CXX)
 
 set(CMAKE_AUTOMOC ON)
 
+include(CTest)
+
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
@@ -39,3 +41,20 @@ install(FILES data/org.archlars.nohangtray.desktop DESTINATION share/application
 
 # Optional, for packaging
 include(GNUInstallDirs)
+
+if (BUILD_TESTING)
+  include(FetchContent)
+  FetchContent_Declare(
+    googletest
+    URL https://github.com/google/googletest/archive/refs/tags/v1.14.0.zip
+  )
+  FetchContent_MakeAvailable(googletest)
+
+  add_executable(NoHangConfig_test
+    tests/NoHangConfig_test.cpp
+    src/NoHangConfig.cpp
+  )
+  target_include_directories(NoHangConfig_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
+  target_link_libraries(NoHangConfig_test PRIVATE Qt6::Core gtest gtest_main)
+  add_test(NAME NoHangConfig_test COMMAND NoHangConfig_test)
+endif()

--- a/tests/NoHangConfig_test.cpp
+++ b/tests/NoHangConfig_test.cpp
@@ -1,0 +1,72 @@
+#include <gtest/gtest.h>
+#include "NoHangConfig.h"
+#include <QTemporaryDir>
+#include <QFile>
+#include <QTextStream>
+#include <QDir>
+
+class NoHangConfigTest : public ::testing::Test {
+protected:
+    void writeConfig(const QString& path, const QString& content) {
+        QFile f(path);
+        ASSERT_TRUE(f.open(QIODevice::WriteOnly | QIODevice::Text));
+        QTextStream ts(&f);
+        ts << content;
+    }
+};
+
+TEST_F(NoHangConfigTest, ParsePercentages) {
+    QTemporaryDir dir;
+    QString cfgPath = dir.filePath("config.conf");
+    writeConfig(cfgPath, "warning_threshold_min_mem=10%\nwarning_threshold_min_swap=10 %\n");
+    NoHangConfig cfg;
+    cfg.ensureParsed(cfgPath);
+    const auto& t = cfg.thresholds();
+    ASSERT_TRUE(t.warn_mem_percent.has_value());
+    EXPECT_DOUBLE_EQ(10.0, t.warn_mem_percent.value());
+    ASSERT_TRUE(t.warn_swap_percent_free.has_value());
+    EXPECT_DOUBLE_EQ(10.0, t.warn_swap_percent_free.value());
+}
+
+TEST_F(NoHangConfigTest, ParseMiBValues) {
+    QTemporaryDir dir;
+    QString cfgPath = dir.filePath("config.conf");
+    writeConfig(cfgPath, "warning_threshold_min_mem=512M\nwarning_threshold_min_swap=512 MiB\n");
+    NoHangConfig cfg;
+    cfg.ensureParsed(cfgPath);
+    const auto& t = cfg.thresholds();
+    ASSERT_TRUE(t.warn_mem_percent.has_value());
+    EXPECT_DOUBLE_EQ(512.0, t.warn_mem_percent.value());
+    ASSERT_TRUE(t.warn_swap_percent_free.has_value());
+    EXPECT_DOUBLE_EQ(512.0, t.warn_swap_percent_free.value());
+}
+
+TEST_F(NoHangConfigTest, FallbackToDefaultPaths) {
+    // Ensure default config exists
+    QString defaultDir = "/usr/share/nohang";
+    QDir().mkpath(defaultDir);
+    QString defaultPath = defaultDir + "/nohang.conf";
+    writeConfig(defaultPath, "hard_threshold_min_mem=10%\n");
+
+    NoHangConfig cfg;
+    cfg.ensureParsed("/nonexistent/path.conf");
+    EXPECT_EQ(defaultPath, cfg.sourcePath());
+    const auto& t = cfg.thresholds();
+    ASSERT_TRUE(t.hard_mem_percent.has_value());
+    EXPECT_DOUBLE_EQ(10.0, t.hard_mem_percent.value());
+
+    QFile::remove(defaultPath);
+}
+
+TEST_F(NoHangConfigTest, IgnoreCommentsAndEmptyLines) {
+    QTemporaryDir dir;
+    QString cfgPath = dir.filePath("config.conf");
+    writeConfig(cfgPath, "# comment\n\nsoft_threshold_min_swap=10%\n@ignored\n");
+    NoHangConfig cfg;
+    cfg.ensureParsed(cfgPath);
+    const auto& t = cfg.thresholds();
+    ASSERT_TRUE(t.soft_swap_percent_free.has_value());
+    EXPECT_DOUBLE_EQ(10.0, t.soft_swap_percent_free.value());
+    EXPECT_FALSE(t.warn_mem_percent.has_value());
+}
+


### PR DESCRIPTION
## Summary
- add GoogleTest-based tests for NoHangConfig parsing
- run tests in CI

## Testing
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68b1086528f48330af570ffbd2bca5f3