### PR TITLE
ci: install ca-certificates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,8 @@ jobs:
           apt-get update
           apt-get install -y --no-install-recommends \
             build-essential cmake ninja-build pkg-config \
-            qt6-base-dev libkf6statusnotifieritem-dev ccache
+            qt6-base-dev libkf6statusnotifieritem-dev ccache \
+            ca-certificates
 
       - name: Cache ccache
         uses: actions/cache@v4


### PR DESCRIPTION
## Summary
- install ca-certificates in CI container so CMake's FetchContent can download dependencies

## Testing
- `cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68b109c6e7148330b594358141d9d576