### PR TITLE
Refactor CMake to build core library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,8 +16,7 @@ find_package(Qt6 REQUIRED COMPONENTS Core Widgets)
 # Docs show: find_package(KF6StatusNotifierItem) then link KF6::StatusNotifierItem
 find_package(KF6StatusNotifierItem REQUIRED)
 
-add_executable(nohang-tray
-  src/main.cpp
+add_library(nohang_core STATIC
   src/TrayApp.cpp
   src/NoHangUnit.cpp
   src/NoHangConfig.cpp
@@ -26,15 +25,13 @@ add_executable(nohang-tray
   src/TooltipBuilder.cpp
   src/ProcessTableAction.cpp
 )
+target_include_directories(nohang_core PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src)
+target_link_libraries(nohang_core
+  PUBLIC Qt6::Core Qt6::Widgets
+  PRIVATE KF6::StatusNotifierItem)
 
-target_include_directories(nohang-tray PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
-
-target_link_libraries(nohang-tray
-  PRIVATE
-    Qt6::Core
-    Qt6::Widgets
-    KF6::StatusNotifierItem
-)
+add_executable(nohang-tray src/main.cpp)
+target_link_libraries(nohang-tray PRIVATE nohang_core Qt6::Core Qt6::Widgets KF6::StatusNotifierItem)
 
 install(TARGETS nohang-tray RUNTIME DESTINATION bin)
 install(FILES data/org.archlars.nohangtray.desktop DESTINATION share/applications)
@@ -50,55 +47,27 @@ if (BUILD_TESTING)
   )
   FetchContent_MakeAvailable(googletest)
 
-  add_executable(NoHangConfig_test
-    tests/NoHangConfig_test.cpp
-    src/NoHangConfig.cpp
-  )
-  target_include_directories(NoHangConfig_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
-  target_link_libraries(NoHangConfig_test PRIVATE Qt6::Core gtest gtest_main)
+  add_executable(NoHangConfig_test tests/NoHangConfig_test.cpp)
+  target_link_libraries(NoHangConfig_test PRIVATE nohang_core Qt6::Core gtest gtest_main)
   add_test(NAME NoHangConfig_test COMMAND NoHangConfig_test)
 
-  add_executable(Thresholds_test
-    tests/Thresholds_test.cpp
-    src/Thresholds.cpp
-    src/SystemSnapshot.cpp
-  )
-  target_include_directories(Thresholds_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
-  target_link_libraries(Thresholds_test PRIVATE Qt6::Core gtest gtest_main)
+  add_executable(Thresholds_test tests/Thresholds_test.cpp)
+  target_link_libraries(Thresholds_test PRIVATE nohang_core Qt6::Core gtest gtest_main)
   add_test(NAME Thresholds_test COMMAND Thresholds_test)
 
-  add_executable(SystemSnapshot_test
-    tests/SystemSnapshot_test.cpp
-    src/SystemSnapshot.cpp
-  )
-  target_include_directories(SystemSnapshot_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
-  target_link_libraries(SystemSnapshot_test PRIVATE Qt6::Core gtest gtest_main)
+  add_executable(SystemSnapshot_test tests/SystemSnapshot_test.cpp)
+  target_link_libraries(SystemSnapshot_test PRIVATE nohang_core Qt6::Core gtest gtest_main)
   add_test(NAME SystemSnapshot_test COMMAND SystemSnapshot_test)
 
-  add_executable(NoHangUnit_test
-    tests/NoHangUnit_test.cpp
-    src/NoHangUnit.cpp
-  )
-  target_include_directories(NoHangUnit_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
-  target_link_libraries(NoHangUnit_test PRIVATE Qt6::Core gtest gtest_main)
+  add_executable(NoHangUnit_test tests/NoHangUnit_test.cpp)
+  target_link_libraries(NoHangUnit_test PRIVATE nohang_core Qt6::Core gtest gtest_main)
   add_test(NAME NoHangUnit_test COMMAND NoHangUnit_test)
 
-  add_executable(TooltipBuilder_test
-    tests/TooltipBuilder_test.cpp
-    src/TooltipBuilder.cpp
-    src/NoHangConfig.cpp
-    src/Thresholds.cpp
-    src/SystemSnapshot.cpp
-  )
-  target_include_directories(TooltipBuilder_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
-  target_link_libraries(TooltipBuilder_test PRIVATE Qt6::Core gtest gtest_main)
+  add_executable(TooltipBuilder_test tests/TooltipBuilder_test.cpp)
+  target_link_libraries(TooltipBuilder_test PRIVATE nohang_core Qt6::Core gtest gtest_main)
   add_test(NAME TooltipBuilder_test COMMAND TooltipBuilder_test)
 
-  add_executable(ProcessTableAction_test
-    tests/ProcessTableAction_test.cpp
-    src/ProcessTableAction.cpp
-  )
-  target_include_directories(ProcessTableAction_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
-  target_link_libraries(ProcessTableAction_test PRIVATE Qt6::Core Qt6::Widgets gtest gtest_main)
+  add_executable(ProcessTableAction_test tests/ProcessTableAction_test.cpp)
+  target_link_libraries(ProcessTableAction_test PRIVATE nohang_core Qt6::Core Qt6::Widgets gtest gtest_main)
   add_test(NAME ProcessTableAction_test COMMAND ProcessTableAction_test)
 endif()


### PR DESCRIPTION
## Summary
- Build core sources as `nohang_core` static library
- Link main executable and tests against shared library
- Simplify test targets to only include test sources

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68b117a154908330b7ad12a0010c6876