### PR TITLE
Add project-wide gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,51 @@
+# Build artifacts
+build/
+build-*/
+CMakeFiles/
+CMakeCache.txt
+cmake_install.cmake
+Makefile
+compile_commands.json
+
+# Qt/KDE auto-generated sources
+moc_*
+ui_*
+qrc_*
+*_automoc.cpp
+*.moc
+
+# Compiled objects and binaries
+*.o
+*.obj
+*.a
+*.so
+*.dll
+*.dylib
+*.lib
+*.exe
+
+# Packaging outputs
+packaging/pkg/
+packaging/src/
+packaging/*.pkg.tar.*
+packaging/*.tar.*
+
+# Test/coverage files
+*.gcda
+*.gcno
+*.profraw
+*.profdata
+
+# IDE/editor files
+*.user
+*.user.*
+*.kdev4
+*.kate-swp
+.vscode/
+.idea/
+*.swp
+*~
+
+# OS-specific files
+.DS_Store
+Thumbs.db


### PR DESCRIPTION
## Summary
- add .gitignore covering build outputs, packaging artifacts, test files, IDE settings, and OS clutter

## Testing
- `cmake -S . -B build && cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68b1195d37e08330875d112ecc4a50ed