### PR TITLE
Use ccache for builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,8 @@ cmake_minimum_required(VERSION 3.24)
 project(nohang-tray VERSION 0.1.0 LANGUAGES CXX)
 
 set(CMAKE_AUTOMOC ON)
+set(CMAKE_CXX_COMPILER_LAUNCHER ccache)
+set(CMAKE_C_COMPILER_LAUNCHER ccache)
 
 include(CTest)
 


### PR DESCRIPTION
## Summary
- enable ccache for both C and C++ compiler launches

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ccache -s`
- `rm -rf build && cmake -S . -B build && cmake --build build`
- `ccache -s`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68b11cfcfdcc8330b3d9d75c6806cc1d