### PR TITLE
fix: fetch gtest when missing in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,18 @@ install(FILES data/org.archlars.nohangtray.desktop DESTINATION share/application
 include(GNUInstallDirs)
 
 if (BUILD_TESTING)
-  find_package(GTest REQUIRED)
+  include(FetchContent)
+  find_package(GTest QUIET)
+  if (NOT GTest_FOUND)
+    message(STATUS "GTest not found, fetching...")
+    FetchContent_Declare(
+      googletest
+      URL https://github.com/google/googletest/archive/refs/tags/v1.14.0.tar.gz
+    )
+    # Prevent overriding the parent project's compiler/linker settings
+    set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+    FetchContent_MakeAvailable(googletest)
+  endif()
 
   add_executable(NoHangConfig_test tests/NoHangConfig_test.cpp)
   target_link_libraries(NoHangConfig_test PRIVATE nohang_core Qt6::Core GTest::gtest GTest::gtest_main)


### PR DESCRIPTION
## Summary
- fall back to downloading Googletest with FetchContent when system package missing

## Testing
- `cmake -S . -B build -G Ninja`
- `cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68b11e5fbdac8330919312b5586e047d