### PR TITLE
Add precompiled header for Qt sources

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,9 +31,11 @@ target_include_directories(nohang_core PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src)
 target_link_libraries(nohang_core
   PUBLIC Qt6::Core Qt6::Widgets
   PRIVATE KF6::StatusNotifierItem)
+target_precompile_headers(nohang_core PRIVATE src/pch.h)
 
 add_executable(nohang-tray src/main.cpp)
 target_link_libraries(nohang-tray PRIVATE nohang_core Qt6::Core Qt6::Widgets KF6::StatusNotifierItem)
+target_precompile_headers(nohang-tray PRIVATE src/pch.h)
 
 install(TARGETS nohang-tray RUNTIME DESTINATION bin)
 install(FILES data/org.archlars.nohangtray.desktop DESTINATION share/applications)
@@ -57,25 +59,31 @@ if (BUILD_TESTING)
 
   add_executable(NoHangConfig_test tests/NoHangConfig_test.cpp)
   target_link_libraries(NoHangConfig_test PRIVATE nohang_core Qt6::Core GTest::gtest GTest::gtest_main)
+  target_precompile_headers(NoHangConfig_test PRIVATE src/pch.h)
   add_test(NAME NoHangConfig_test COMMAND NoHangConfig_test)
 
   add_executable(Thresholds_test tests/Thresholds_test.cpp)
   target_link_libraries(Thresholds_test PRIVATE nohang_core Qt6::Core GTest::gtest GTest::gtest_main)
+  target_precompile_headers(Thresholds_test PRIVATE src/pch.h)
   add_test(NAME Thresholds_test COMMAND Thresholds_test)
 
   add_executable(SystemSnapshot_test tests/SystemSnapshot_test.cpp)
   target_link_libraries(SystemSnapshot_test PRIVATE nohang_core Qt6::Core GTest::gtest GTest::gtest_main)
+  target_precompile_headers(SystemSnapshot_test PRIVATE src/pch.h)
   add_test(NAME SystemSnapshot_test COMMAND SystemSnapshot_test)
 
   add_executable(NoHangUnit_test tests/NoHangUnit_test.cpp)
   target_link_libraries(NoHangUnit_test PRIVATE nohang_core Qt6::Core GTest::gtest GTest::gtest_main)
+  target_precompile_headers(NoHangUnit_test PRIVATE src/pch.h)
   add_test(NAME NoHangUnit_test COMMAND NoHangUnit_test)
 
   add_executable(TooltipBuilder_test tests/TooltipBuilder_test.cpp)
   target_link_libraries(TooltipBuilder_test PRIVATE nohang_core Qt6::Core GTest::gtest GTest::gtest_main)
+  target_precompile_headers(TooltipBuilder_test PRIVATE src/pch.h)
   add_test(NAME TooltipBuilder_test COMMAND TooltipBuilder_test)
 
   add_executable(ProcessTableAction_test tests/ProcessTableAction_test.cpp)
   target_link_libraries(ProcessTableAction_test PRIVATE nohang_core Qt6::Core Qt6::Widgets GTest::gtest GTest::gtest_main)
+  target_precompile_headers(ProcessTableAction_test PRIVATE src/pch.h)
   add_test(NAME ProcessTableAction_test COMMAND ProcessTableAction_test)
 endif()

--- a/src/NoHangConfig.cpp
+++ b/src/NoHangConfig.cpp
@@ -1,4 +1,5 @@
 // ===== src/NoHangConfig.cpp =====
+#include "pch.h"
 #include "NoHangConfig.h"
 #include <QFile>
 #include <QFileInfo>

--- a/src/NoHangUnit.cpp
+++ b/src/NoHangUnit.cpp
@@ -1,4 +1,5 @@
 // ===== src/NoHangUnit.cpp =====
+#include "pch.h"
 #include "NoHangUnit.h"
 #include <QProcess>
 #include <QStringList>

--- a/src/ProcessTableAction.cpp
+++ b/src/ProcessTableAction.cpp
@@ -1,4 +1,5 @@
 // ===== src/ProcessTableAction.cpp =====
+#include "pch.h"
 #include "ProcessTableAction.h"
 #include <QAction>
 #include <QProcess>

--- a/src/SystemSnapshot.cpp
+++ b/src/SystemSnapshot.cpp
@@ -1,4 +1,5 @@
 // ===== src/SystemSnapshot.cpp =====
+#include "pch.h"
 #include "SystemSnapshot.h"
 #include <QFile>
 #include <QTextStream>

--- a/src/Thresholds.cpp
+++ b/src/Thresholds.cpp
@@ -1,4 +1,5 @@
 // ===== src/Thresholds.cpp =====
+#include "pch.h"
 #include "Thresholds.h"
 
 static ThresholdValue makeVal(std::optional<double> pct, double totalMiB) {

--- a/src/TooltipBuilder.cpp
+++ b/src/TooltipBuilder.cpp
@@ -1,4 +1,5 @@
 // ===== src/TooltipBuilder.cpp =====
+#include "pch.h"
 #include "TooltipBuilder.h"
 #include "NoHangConfig.h"
 #include "SystemSnapshot.h"

--- a/src/TrayApp.cpp
+++ b/src/TrayApp.cpp
@@ -1,4 +1,5 @@
 // ===== src/TrayApp.cpp =====
+#include "pch.h"
 #include "TrayApp.h"
 #include "NoHangUnit.h"
 #include "NoHangConfig.h"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,4 +1,5 @@
 // ===== src/main.cpp =====
+#include "pch.h"
 #include <QApplication>
 #include "TrayApp.h"
 

--- a/src/pch.h
+++ b/src/pch.h
@@ -1,0 +1,3 @@
+#pragma once
+#include <QtCore>
+#include <QtWidgets>

--- a/tests/NoHangConfig_test.cpp
+++ b/tests/NoHangConfig_test.cpp
@@ -1,3 +1,4 @@
+#include "pch.h"
 #include <gtest/gtest.h>
 #include "NoHangConfig.h"
 #include <QTemporaryDir>

--- a/tests/NoHangUnit_test.cpp
+++ b/tests/NoHangUnit_test.cpp
@@ -1,3 +1,4 @@
+#include "pch.h"
 #include <gtest/gtest.h>
 #define private public
 #include "NoHangUnit.h"

--- a/tests/ProcessTableAction_test.cpp
+++ b/tests/ProcessTableAction_test.cpp
@@ -1,3 +1,4 @@
+#include "pch.h"
 #include <gtest/gtest.h>
 #include <QApplication>
 #include <QAction>

--- a/tests/SystemSnapshot_test.cpp
+++ b/tests/SystemSnapshot_test.cpp
@@ -1,3 +1,4 @@
+#include "pch.h"
 #include <gtest/gtest.h>
 #include "SystemSnapshot.h"
 

--- a/tests/Thresholds_test.cpp
+++ b/tests/Thresholds_test.cpp
@@ -1,3 +1,4 @@
+#include "pch.h"
 #include <gtest/gtest.h>
 #include "Thresholds.h"
 

--- a/tests/TooltipBuilder_test.cpp
+++ b/tests/TooltipBuilder_test.cpp
@@ -1,3 +1,4 @@
+#include "pch.h"
 #include <gtest/gtest.h>
 #define private public
 #include "NoHangConfig.h"


### PR DESCRIPTION
## Summary
- Introduce shared `pch.h` with common Qt headers
- Enable CMake precompiled headers for core library, executable and tests
- Include `pch.h` first in all source and test files

## Testing
- `cmake -S . -B build && cmake --build build`
- `cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68b11f7cd2588330a3f08432882f6b6a