### PR TITLE
Refactor CMake to split GUI from core

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,22 +19,26 @@ find_package(Qt6 REQUIRED COMPONENTS Core Widgets)
 find_package(KF6StatusNotifierItem REQUIRED)
 
 add_library(nohang_core STATIC
-  src/TrayApp.cpp
   src/NoHangUnit.cpp
   src/NoHangConfig.cpp
   src/SystemSnapshot.cpp
   src/Thresholds.cpp
   src/TooltipBuilder.cpp
-  src/ProcessTableAction.cpp
 )
 target_include_directories(nohang_core PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src)
-target_link_libraries(nohang_core
-  PUBLIC Qt6::Core Qt6::Widgets
-  PRIVATE KF6::StatusNotifierItem)
+target_link_libraries(nohang_core PUBLIC Qt6::Core)
 target_precompile_headers(nohang_core PRIVATE src/pch.h)
 
+add_library(tray_ui STATIC
+  src/TrayApp.cpp
+  src/ProcessTableAction.cpp
+)
+target_include_directories(tray_ui PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src)
+target_link_libraries(tray_ui PUBLIC Qt6::Widgets KF6::StatusNotifierItem)
+target_precompile_headers(tray_ui PRIVATE src/pch.h)
+
 add_executable(nohang-tray src/main.cpp)
-target_link_libraries(nohang-tray PRIVATE nohang_core Qt6::Core Qt6::Widgets KF6::StatusNotifierItem)
+target_link_libraries(nohang-tray PRIVATE tray_ui nohang_core)
 target_precompile_headers(nohang-tray PRIVATE src/pch.h)
 
 install(TARGETS nohang-tray RUNTIME DESTINATION bin)
@@ -83,7 +87,7 @@ if (BUILD_TESTING)
   add_test(NAME TooltipBuilder_test COMMAND TooltipBuilder_test)
 
   add_executable(ProcessTableAction_test tests/ProcessTableAction_test.cpp)
-  target_link_libraries(ProcessTableAction_test PRIVATE nohang_core Qt6::Core Qt6::Widgets GTest::gtest GTest::gtest_main)
+  target_link_libraries(ProcessTableAction_test PRIVATE tray_ui nohang_core GTest::gtest GTest::gtest_main)
   target_precompile_headers(ProcessTableAction_test PRIVATE src/pch.h)
   add_test(NAME ProcessTableAction_test COMMAND ProcessTableAction_test)
 endif()

--- a/src/pch.h
+++ b/src/pch.h
@@ -1,3 +1,2 @@
 #pragma once
 #include <QtCore>
-#include <QtWidgets>


### PR DESCRIPTION
## Summary
- Extract GUI sources into new `tray_ui` library
- Limit `nohang_core` to non-GUI sources and Qt6::Core dependency
- Link `nohang-tray` and `ProcessTableAction_test` against `tray_ui`

## Testing
- `cmake --build .`
- `ctest --output-on-failure`
- `ldd NoHangConfig_test | grep Qt6`


------
https://chatgpt.com/codex/tasks/task_e_68b1292dde488330b4c52a41d2745120