### PR TITLE
Allow SystemSnapshot path overrides to improve test coverage

### DIFF
--- a/src/SystemSnapshot.h
+++ b/src/SystemSnapshot.h
@@ -32,6 +32,7 @@ class SystemSnapshot : public QObject {
     Q_OBJECT
 public:
     explicit SystemSnapshot(QObject* parent = nullptr);
+    SystemSnapshot(const QString& procRoot, const QString& sysRoot, QObject* parent = nullptr);
 
     void refresh();
 
@@ -45,6 +46,8 @@ private:
     void readZram();
     void readPsi();
 
+    QString m_procRoot{QStringLiteral("/proc")};
+    QString m_sysRoot{QStringLiteral("/sys")};
     MemInfo m_mem;
     ZramInfo m_zram;
     PsiInfo m_psi;


### PR DESCRIPTION
## Summary
- allow injecting custom `/proc` and `/sys` roots into `SystemSnapshot`
- test meminfo parsing and PSI fallback with fake proc data

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build`

------
https://chatgpt.com/codex/tasks/task_e_68b12c663c988330913c29470ba0e6db