### PR TITLE
Improve SystemSnapshot error handling and tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Qt 6
-find_package(Qt6 REQUIRED COMPONENTS Core Widgets)
+find_package(Qt6 REQUIRED COMPONENTS Core Widgets Test)
 
 # KDE Frameworks 6, Status Notifier Item
 # Docs show: find_package(KF6StatusNotifierItem) then link KF6::StatusNotifierItem
@@ -72,7 +72,7 @@ if (BUILD_TESTING)
   add_test(NAME Thresholds_test COMMAND Thresholds_test)
 
   add_executable(SystemSnapshot_test tests/SystemSnapshot_test.cpp)
-  target_link_libraries(SystemSnapshot_test PRIVATE nohang_core Qt6::Core GTest::gtest GTest::gtest_main)
+  target_link_libraries(SystemSnapshot_test PRIVATE nohang_core Qt6::Core Qt6::Test GTest::gtest GTest::gtest_main)
   target_precompile_headers(SystemSnapshot_test PRIVATE src/pch.h)
   add_test(NAME SystemSnapshot_test COMMAND SystemSnapshot_test)
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ cp data/org.archlars.nohangtray.desktop ~/.config/autostart/
 * Discovers config via `systemctl show -p ExecStart nohang-desktop.service`.
 * Parses thresholds from the discovered config, falling back to `/etc/nohang/nohang-desktop.conf` and `/usr/share/nohang/nohang.conf`.
 * Reads `/proc/meminfo`, `/proc/pressure/memory`, and `/sys/block/zram0/{disksize,mm_stat}` to populate the tooltip.
+* Logs a warning if `/proc/meminfo` cannot be opened.
 
 ## Layout
 ```bash

--- a/tests/SystemSnapshot_test.cpp
+++ b/tests/SystemSnapshot_test.cpp
@@ -2,18 +2,31 @@
 #include <gtest/gtest.h>
 #include "SystemSnapshot.h"
 #include <QTemporaryDir>
+#include <QTest>
 
 TEST(SystemSnapshotTest, RefreshPopulatesFields)
 {
     SystemSnapshot snap;
     snap.refresh();
-    EXPECT_GE(snap.mem().memTotalMiB, 0);
-    EXPECT_GE(snap.mem().memAvailableMiB, 0);
-    EXPECT_GE(snap.mem().memAvailablePercent, 0);
+    EXPECT_GT(snap.mem().memTotalMiB, 0);
+    EXPECT_GT(snap.mem().memAvailableMiB, 0);
+    EXPECT_GT(snap.mem().memAvailablePercent, 0);
     EXPECT_LE(snap.mem().memAvailablePercent, 100);
     EXPECT_GE(snap.mem().swapFreeMiB, 0);
     EXPECT_GE(snap.psi().some_avg10, 0);
     EXPECT_GE(snap.psi().full_avg10, 0);
+}
+
+TEST(SystemSnapshotTest, MissingMeminfoLogsWarning)
+{
+    QTemporaryDir procDir;
+    QTemporaryDir sysDir;
+    SystemSnapshot snap(procDir.path(), sysDir.path());
+
+    QTest::ignoreMessage(QtWarningMsg, QRegularExpression("SystemSnapshot: cannot open .*meminfo"));
+    snap.refresh();
+
+    EXPECT_DOUBLE_EQ(0.0, snap.mem().memTotalMiB);
 }
 
 TEST(SystemSnapshotTest, ParsesMeminfoAndHandlesMissingPsi)


### PR DESCRIPTION
## Summary
- Ensure SystemSnapshot reads meminfo correctly and logs a warning when missing
- Strengthen SystemSnapshot tests with positive field checks and missing meminfo case
- Link Qt6 Test module for tests and document warning behavior

## Testing
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68b1417708488330814808d184062b2c