### PR TITLE
fix: handle indented meminfo

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ cp data/org.archlars.nohangtray.desktop ~/.config/autostart/
 * The icon appears only when `nohang` is protecting your system.
 * Hovering the icon shows memory limits from your configuration alongside current usage.
 * This helps you gauge how close you are to running out of memory.
+* Robust `/proc/meminfo` parsing tolerates leading whitespace.
 
 ## Technical Details
 

--- a/src/SystemSnapshot.cpp
+++ b/src/SystemSnapshot.cpp
@@ -27,13 +27,16 @@ void SystemSnapshot::readMeminfo() {
     QTextStream ts(&f);
     double memTotalKiB = 0, memAvailableKiB = 0, swapTotalKiB = 0, swapFreeKiB = 0;
     QString line;
+    QRegularExpression re(R"(^\s*([A-Za-z_]+):\s+([0-9]+))");
     while (ts.readLineInto(&line)) {
-        const QStringList parts = line.split(QRegularExpression("\\s+"), Qt::SkipEmptyParts);
-        if (parts.size() < 2) continue;
-        if (line.startsWith("MemTotal:"))       memTotalKiB       = parts[1].toDouble();
-        else if (line.startsWith("MemAvailable:")) memAvailableKiB = parts[1].toDouble();
-        else if (line.startsWith("SwapTotal:"))  swapTotalKiB      = parts[1].toDouble();
-        else if (line.startsWith("SwapFree:"))   swapFreeKiB       = parts[1].toDouble();
+        auto m = re.match(line);
+        if (!m.hasMatch()) continue;
+        const QString key = m.captured(1);
+        const double val  = m.captured(2).toDouble();
+        if (key == QLatin1String("MemTotal"))       memTotalKiB       = val;
+        else if (key == QLatin1String("MemAvailable")) memAvailableKiB = val;
+        else if (key == QLatin1String("SwapTotal"))  swapTotalKiB      = val;
+        else if (key == QLatin1String("SwapFree"))   swapFreeKiB       = val;
     }
     m_mem.memTotalMiB = memTotalKiB / 1024.0;
     m_mem.memAvailableMiB = memAvailableKiB / 1024.0;

--- a/tests/SystemSnapshot_test.cpp
+++ b/tests/SystemSnapshot_test.cpp
@@ -55,3 +55,26 @@ TEST(SystemSnapshotTest, ParsesMeminfoAndHandlesMissingPsi)
     EXPECT_DOUBLE_EQ(0.0, snap.psi().some_avg10);
     EXPECT_DOUBLE_EQ(0.0, snap.psi().full_avg10);
 }
+
+TEST(SystemSnapshotTest, ParsesMeminfoWithLeadingSpaces)
+{
+    QTemporaryDir procDir;
+    QTemporaryDir sysDir;
+
+    QFile meminfo(procDir.filePath("meminfo"));
+    ASSERT_TRUE(meminfo.open(QIODevice::WriteOnly | QIODevice::Text));
+    QTextStream ts(&meminfo);
+    ts << "   MemTotal:       2048 kB\n";
+    ts << "   MemAvailable:   1024 kB\n";
+    ts << "   SwapTotal:       512 kB\n";
+    ts << "   SwapFree:        256 kB\n";
+    meminfo.close();
+
+    SystemSnapshot snap(procDir.path(), sysDir.path());
+    snap.refresh();
+
+    EXPECT_DOUBLE_EQ(2.0, snap.mem().memTotalMiB);
+    EXPECT_DOUBLE_EQ(1.0, snap.mem().memAvailableMiB);
+    EXPECT_DOUBLE_EQ(0.5, snap.mem().swapTotalMiB);
+    EXPECT_DOUBLE_EQ(0.25, snap.mem().swapFreeMiB);
+}


### PR DESCRIPTION
## Summary
- make meminfo parser resilient to leading whitespace
- test SystemSnapshot against indented meminfo
- document robust meminfo parsing

## Testing
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68b144ad3094833088693450d1c11c8f