### PR TITLE
docs: document Ninja build

### DIFF
--- a/CODING_GUIDE.md
+++ b/CODING_GUIDE.md
@@ -2,7 +2,7 @@
 
 This repository builds a small Qt/KDE tray utility. Key points:
 
-* **Build**: `cmake -S . -B build && cmake --build build`
+* **Build**: `cmake -G Ninja -S . -B build && cmake --build build -j$(nproc)`
 * **Tests**: `ctest --test-dir build`
 * **Entry point**: `src/main.cpp` boots `TrayApp`, which wires up the modules.
 * **Modules**:

--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@
    ```bash
    sudo pacman -S --needed base-devel cmake qt6-base kstatusnotifieritem
    ```
-2. Build the project:
+2. Generate the build directory and compile:
    ```bash
-   cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
-   cmake --build build -j
+   cmake -G Ninja -S . -B build -DCMAKE_BUILD_TYPE=Release
+   cmake --build build -j$(nproc)
    ```
 
 ### Other distributions
@@ -24,6 +24,13 @@
   ```bash
   sudo dnf install @development-tools cmake qt6-qtbase-devel kf6-kstatusnotifieritem-devel
   ```
+
+After installing dependencies, generate the build directory and compile:
+
+```bash
+cmake -G Ninja -S . -B build -DCMAKE_BUILD_TYPE=Release
+cmake --build build -j$(nproc)
+```
 
 ## Usage
 


### PR DESCRIPTION
## Summary
- clarify Ninja-based build directory generation and parallel compilation in README
- mention Ninja generator and core-aware build in coding guide

## Testing
- `cmake -G Ninja -S . -B build`
- `cmake --build build -j$(nproc)`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68b149252c588330a1e8c899192bc749