### PR TITLE
docs: recommend ccache for faster rebuilds

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,3 +4,5 @@ Refer to `CODING_GUIDE.md` for an overview of the project structure, build, and 
 
 Update `README` and other relevant documentation after any changes.
 
+Install `ccache` and configure its maximum size (e.g., run `ccache -M 5G`) to speed up rebuilds.
+


### PR DESCRIPTION
## Summary
- document installing ccache and setting CCACHE_MAXSIZE for speedier rebuilds

## Testing
- `cmake -G Ninja -S . -B build && cmake --build build -j$(nproc)`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68b14a2df2f483308857f72a8d3c75a2