### PR TITLE
Handle swap totals via /proc/swaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ cp data/org.archlars.nohangtray.desktop ~/.config/autostart/
 
 * Discovers config via `systemctl show -p ExecStart nohang-desktop.service`.
 * Parses thresholds from the discovered config, falling back to `/etc/nohang/nohang-desktop.conf` and `/usr/share/nohang/nohang.conf`.
-* Reads `/proc/meminfo`, `/proc/pressure/memory`, and `/sys/block/zram0/{disksize,mm_stat}` to populate the tooltip.
+* Reads `/proc/meminfo`, `/proc/swaps`, `/proc/pressure/memory`, and `/sys/block/zram0/{disksize,mm_stat}` to populate the tooltip.
 * Logs a warning if `/proc/meminfo` cannot be opened.
 
 ## Layout


### PR DESCRIPTION
## Summary
- Parse /proc/swaps to fill swap totals and free when /proc/meminfo lacks this data
- Update SystemSnapshot tests to cover the /proc/swaps fallback
- Note /proc/swaps usage in the README

## Testing
- `ctest --test-dir build`
- `cmake -G Ninja -S . -B build-release -DBUILD_TESTING=OFF -DCMAKE_BUILD_TYPE=Release && cmake --build build-release -j$(nproc)`

------
https://chatgpt.com/codex/tasks/task_e_68b1512a0ea88330b3fa0befaef3d89d