### PR TITLE
Handle swap detection via /proc/swaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,13 +55,13 @@ cp data/org.archlars.nohangtray.desktop ~/.config/autostart/
 * The icon appears only when `nohang` is protecting your system.
 * Hovering the icon shows memory limits from your configuration alongside current usage.
 * This helps you gauge how close you are to running out of memory.
-* Robust `/proc/meminfo` parsing tolerates leading whitespace.
+* Robust `/proc/meminfo` parsing tolerates leading whitespace, and `/proc/swaps` totals ensure swap usage is always reported.
 
 ## Technical Details
 
 * Discovers config via `systemctl show -p ExecStart nohang-desktop.service`.
 * Parses thresholds from the discovered config, falling back to `/etc/nohang/nohang-desktop.conf` and `/usr/share/nohang/nohang.conf`.
-* Reads `/proc/meminfo`, `/proc/pressure/memory`, and `/sys/block/zram0/{disksize,mm_stat}` to populate the tooltip.
+* Reads `/proc/meminfo`, `/proc/swaps`, `/proc/pressure/memory`, and `/sys/block/zram0/{disksize,mm_stat}` to populate the tooltip.
 * Logs a warning if `/proc/meminfo` cannot be opened.
 
 ## Layout

--- a/tests/SystemSnapshot_test.cpp
+++ b/tests/SystemSnapshot_test.cpp
@@ -78,3 +78,59 @@ TEST(SystemSnapshotTest, ParsesMeminfoWithLeadingSpaces)
     EXPECT_DOUBLE_EQ(0.5, snap.mem().swapTotalMiB);
     EXPECT_DOUBLE_EQ(0.25, snap.mem().swapFreeMiB);
 }
+
+TEST(SystemSnapshotTest, ParsesSwapsWhenMeminfoMissingSwap)
+{
+    QTemporaryDir procDir;
+    QTemporaryDir sysDir;
+
+    // meminfo without swap stats
+    QFile meminfo(procDir.filePath("meminfo"));
+    ASSERT_TRUE(meminfo.open(QIODevice::WriteOnly | QIODevice::Text));
+    QTextStream ts(&meminfo);
+    ts << "MemTotal:       2048 kB\n";
+    ts << "MemAvailable:   1024 kB\n";
+    meminfo.close();
+
+    QFile swaps(procDir.filePath("swaps"));
+    ASSERT_TRUE(swaps.open(QIODevice::WriteOnly | QIODevice::Text));
+    QTextStream tsw(&swaps);
+    tsw << "Filename\tType\tSize\tUsed\tPriority\n";
+    tsw << "/dev/zram0\tpartition\t512\t256\t100\n";
+    swaps.close();
+
+    SystemSnapshot snap(procDir.path(), sysDir.path());
+    snap.refresh();
+
+    EXPECT_DOUBLE_EQ(0.5, snap.mem().swapTotalMiB);
+    EXPECT_DOUBLE_EQ(0.25, snap.mem().swapFreeMiB);
+    EXPECT_DOUBLE_EQ(50.0, snap.mem().swapFreePercent);
+}
+
+TEST(SystemSnapshotTest, ParsesMultipleSwapEntries)
+{
+    QTemporaryDir procDir;
+    QTemporaryDir sysDir;
+
+    QFile meminfo(procDir.filePath("meminfo"));
+    ASSERT_TRUE(meminfo.open(QIODevice::WriteOnly | QIODevice::Text));
+    QTextStream ts(&meminfo);
+    ts << "MemTotal:       2048 kB\n";
+    ts << "MemAvailable:   1024 kB\n";
+    meminfo.close();
+
+    QFile swaps(procDir.filePath("swaps"));
+    ASSERT_TRUE(swaps.open(QIODevice::WriteOnly | QIODevice::Text));
+    QTextStream tsw(&swaps);
+    tsw << "Filename Type Size Used Priority\n";
+    tsw << "/dev/zram0 partition 512 128 100\n";
+    tsw << "/swapfile file 1024 512 -2\n";
+    swaps.close();
+
+    SystemSnapshot snap(procDir.path(), sysDir.path());
+    snap.refresh();
+
+    EXPECT_DOUBLE_EQ(1.5, snap.mem().swapTotalMiB);
+    EXPECT_DOUBLE_EQ(0.875, snap.mem().swapFreeMiB);
+    EXPECT_NEAR(58.3333, snap.mem().swapFreePercent, 0.001);
+}


### PR DESCRIPTION
## Summary
- parse `/proc/swaps` to compute swap totals when `/proc/meminfo` lacks them
- test swap parsing for missing meminfo entries and multiple swap devices
- document `/proc/swaps` usage in README

## Testing
- `cmake --build build --target SystemSnapshot_test`
- `ctest --test-dir build -R SystemSnapshot_test`
- `cmake -G Ninja -S . -B build_release -DBUILD_TESTING=OFF -DCMAKE_BUILD_TYPE=Release && cmake --build build_release --target nohang-tray`


------
https://chatgpt.com/codex/tasks/task_e_68b1546441948330932eb5097064b0b0