### PR TITLE
Fix tooltip percent handling and test swap output

### DIFF
--- a/src/TrayApp.cpp
+++ b/src/TrayApp.cpp
@@ -22,9 +22,7 @@ TrayApp::TrayApp(QObject* parent) : QObject(parent) {}
 
 QString TrayApp::escapePercent(const QString& s)
 {
-    QString out = s;
-    out.replace(QStringLiteral("%"), QStringLiteral("%%"));
-    return out;
+    return s;
 }
 
 void TrayApp::start() {
@@ -103,7 +101,7 @@ void TrayApp::refreshTooltip() {
     // Build "configured vs current" text for RAM, swap, zram, PSI
     const QString tipTitle = QStringLiteral("nohang status");
     const QString tipIcon  = QStringLiteral("security-medium");
-    const QString tipText  = escapePercent(m_tooltip->build(*m_cfg, *m_snapshot, m_unit->isActive(), m_unit->resolvedConfigPath()));
+    const QString tipText  = m_tooltip->build(*m_cfg, *m_snapshot, m_unit->isActive(), m_unit->resolvedConfigPath());
 
     // KStatusNotifierItem tooltips take icon-name, title, subtitle
     m_sni->setToolTip(tipIcon, tipTitle, tipText);

--- a/src/TrayApp.h
+++ b/src/TrayApp.h
@@ -26,8 +26,9 @@ public:
     ~TrayApp();  // out-of-line definition in the .cpp
     void start();
 
-    // Utility method exposed for testing: doubles percent signs so that
-    // KStatusNotifierItem does not treat them as positional arguments.
+    // Utility method exposed for testing; currently returns the input string
+    // unchanged. Retained for compatibility if tooltips require escaping in
+    // the future.
     static QString escapePercent(const QString& s);
 
 private slots:

--- a/tests/TooltipBuilder_test.cpp
+++ b/tests/TooltipBuilder_test.cpp
@@ -36,6 +36,7 @@ TEST(TooltipBuilderTest, BuildsSummary)
     EXPECT_TRUE(out.contains("status: active"));
     EXPECT_TRUE(out.contains("config: /path.cfg"));
     EXPECT_TRUE(out.contains("warn if free < 10.0 %"));
+    EXPECT_TRUE(out.contains("Swap:\n  free: 500 MiB (50.0 %)\n"));
     EXPECT_TRUE(out.contains("warn if used > 30.0 %"));
     EXPECT_TRUE(out.contains("PSI:"));
     EXPECT_TRUE(out.contains("metric: full_avg10"));

--- a/tests/TrayApp_test.cpp
+++ b/tests/TrayApp_test.cpp
@@ -6,5 +6,5 @@ TEST(TrayAppTest, EscapePercent)
 {
     const QString input = "value 42 %";
     const QString output = TrayApp::escapePercent(input);
-    EXPECT_EQ(QStringLiteral("value 42 %%"), output);
+    EXPECT_EQ(QStringLiteral("value 42 %"), output);
 }


### PR DESCRIPTION
## Summary
- Stop duplicating % signs in tray tooltip text
- Test that tooltip builder includes swap usage line
- Verify percent escaping is a no-op

## Testing
- `ctest -R "TrayApp_test|TooltipBuilder_test" --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68b15bb1a0b88330b854453b45223361