### PR TITLE
Show tray icon severity based on memory thresholds

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ cp data/org.archlars.nohangtray.desktop ~/.config/autostart/
 * The icon appears only when `nohang` is protecting your system.
 * Hovering the icon shows memory limits from your configuration alongside current usage.
 * This helps you gauge how close you are to running out of memory.
+* Icon color reflects severity: green when resources are plentiful, yellow when warn thresholds are reached, and red for critical conditions.
 * Robust `/proc/meminfo` parsing tolerates leading whitespace, and `/proc/swaps` totals ensure swap usage is always reported.
 
 ## Technical Details

--- a/src/TrayApp.cpp
+++ b/src/TrayApp.cpp
@@ -1,122 +1,167 @@
 // ===== src/TrayApp.cpp =====
-#include "pch.h"
 #include "TrayApp.h"
-#include "NoHangUnit.h"
 #include "NoHangConfig.h"
-#include "SystemSnapshot.h"
-#include "TooltipBuilder.h"
+#include "NoHangUnit.h"
 #include "ProcessTableAction.h"
+#include "SystemSnapshot.h"
 #include "Thresholds.h"
+#include "TooltipBuilder.h"
+#include "pch.h"
 
-#include <QTimer>
-#include <QFileInfo>
-#include <QAction>
 #include <KStatusNotifierItem>
+#include <QAction>
+#include <QFileInfo>
+#include <QTimer>
 
 static constexpr int kPollMs = 5000;
 static constexpr int kCfgWatchMs = 3000;
 
 TrayApp::~TrayApp() = default;
 
-TrayApp::TrayApp(QObject* parent) : QObject(parent) {}
+TrayApp::TrayApp(QObject *parent) : QObject(parent) {}
 
-QString TrayApp::escapePercent(const QString& s)
-{
-    return s;
+QString TrayApp::escapePercent(const QString &s) { return s; }
+
+static bool below(double current, const std::optional<double> &threshold) {
+  return threshold.has_value() && current < *threshold;
+}
+
+static bool above(double current, const std::optional<double> &threshold) {
+  return threshold.has_value() && current > *threshold;
+}
+
+QString TrayApp::iconNameFor(const NoHangConfig &cfg,
+                             const SystemSnapshot &snap) {
+  const ThresholdSet th = Thresholds::compute(cfg.thresholds(), snap);
+
+  // Choose PSI metric if thresholds configure one; default to full_avg10
+  double psiVal = snap.psi().full_avg10;
+  if (th.psi_metrics.contains(QStringLiteral("some")))
+    psiVal = snap.psi().some_avg10;
+
+  const bool critical =
+      below(snap.mem().memAvailableMiB, th.hard_mem_free.mib) ||
+      below(snap.mem().memAvailableMiB, th.soft_mem_free.mib) ||
+      below(snap.mem().swapFreeMiB, th.hard_swap_free.mib) ||
+      below(snap.mem().swapFreeMiB, th.soft_swap_free.mib) ||
+      above(snap.zram().origDataMiB, th.hard_zram_used.mib) ||
+      above(snap.zram().origDataMiB, th.soft_zram_used.mib) ||
+      (th.hard_psi && psiVal > *th.hard_psi) ||
+      (th.soft_psi && psiVal > *th.soft_psi);
+
+  if (critical)
+    return QStringLiteral("security-high");
+
+  const bool warning =
+      below(snap.mem().memAvailableMiB, th.warn_mem_free.mib) ||
+      below(snap.mem().swapFreeMiB, th.warn_swap_free.mib) ||
+      above(snap.zram().origDataMiB, th.warn_zram_used.mib) ||
+      (th.warn_psi && psiVal > *th.warn_psi);
+
+  if (warning)
+    return QStringLiteral("security-medium");
+
+  return QStringLiteral("security-low");
 }
 
 void TrayApp::start() {
-    ensureModels();
-    setupStatusItem();
-    setupTimers();
-    tick();
+  ensureModels();
+  setupStatusItem();
+  setupTimers();
+  tick();
 }
 
 void TrayApp::ensureModels() {
-    if (!m_unit)    m_unit    = std::make_unique<NoHangUnit>(this);
-    if (!m_cfg)     m_cfg     = std::make_unique<NoHangConfig>(this);
-    if (!m_snapshot)m_snapshot= std::make_unique<SystemSnapshot>(this);
-    if (!m_tooltip) m_tooltip = std::make_unique<TooltipBuilder>(this);
-    if (!m_procAction) m_procAction = std::make_unique<ProcessTableAction>(this);
+  if (!m_unit)
+    m_unit = std::make_unique<NoHangUnit>(this);
+  if (!m_cfg)
+    m_cfg = std::make_unique<NoHangConfig>(this);
+  if (!m_snapshot)
+    m_snapshot = std::make_unique<SystemSnapshot>(this);
+  if (!m_tooltip)
+    m_tooltip = std::make_unique<TooltipBuilder>(this);
+  if (!m_procAction)
+    m_procAction = std::make_unique<ProcessTableAction>(this);
 }
 
 void TrayApp::setupStatusItem() {
-    m_sni = std::make_unique<KStatusNotifierItem>(this);
-    m_sni->setCategory(KStatusNotifierItem::SystemServices);
-    m_sni->setTitle(QStringLiteral("nohang"));
-    // Active or passive icon will be set in refreshIcon
-    m_sni->setStatus(KStatusNotifierItem::Active);
-    if (auto* menu = m_sni->contextMenu()) {
-        QAction* act = m_procAction->makeAction(menu, m_unit->resolvedConfigPath());
-        menu->addAction(act);
-    }
+  m_sni = std::make_unique<KStatusNotifierItem>(this);
+  m_sni->setCategory(KStatusNotifierItem::SystemServices);
+  m_sni->setTitle(QStringLiteral("nohang"));
+  // Active or passive icon will be set in refreshIcon
+  m_sni->setStatus(KStatusNotifierItem::Active);
+  if (auto *menu = m_sni->contextMenu()) {
+    QAction *act = m_procAction->makeAction(menu, m_unit->resolvedConfigPath());
+    menu->addAction(act);
+  }
 }
 
 void TrayApp::setupTimers() {
-    m_pollTimer = new QTimer(this);
-    m_pollTimer->setInterval(kPollMs);
-    connect(m_pollTimer, &QTimer::timeout, this, &TrayApp::tick);
-    m_pollTimer->start();
+  m_pollTimer = new QTimer(this);
+  m_pollTimer->setInterval(kPollMs);
+  connect(m_pollTimer, &QTimer::timeout, this, &TrayApp::tick);
+  m_pollTimer->start();
 
-    m_cfgWatchTimer = new QTimer(this);
-    m_cfgWatchTimer->setInterval(kCfgWatchMs);
-    connect(m_cfgWatchTimer, &QTimer::timeout, this, &TrayApp::onConfigMaybeChanged);
-    m_cfgWatchTimer->start();
+  m_cfgWatchTimer = new QTimer(this);
+  m_cfgWatchTimer->setInterval(kCfgWatchMs);
+  connect(m_cfgWatchTimer, &QTimer::timeout, this,
+          &TrayApp::onConfigMaybeChanged);
+  m_cfgWatchTimer->start();
 }
 
 void TrayApp::tick() {
-    // Detect running unit and config path
-    const bool active = m_unit->isActive();
-    const QString cfgPath = m_unit->configPath();
-    if (cfgPath != m_configPathCache) {
-        m_configPathCache = cfgPath;
-        m_configMtimeCache = 0; // force re-parse
-    }
+  // Detect running unit and config path
+  const bool active = m_unit->isActive();
+  const QString cfgPath = m_unit->configPath();
+  if (cfgPath != m_configPathCache) {
+    m_configPathCache = cfgPath;
+    m_configMtimeCache = 0; // force re-parse
+  }
 
-    // Parse thresholds from the current config, or defaults
-    m_cfg->ensureParsed(cfgPath);
+  // Parse thresholds from the current config, or defaults
+  m_cfg->ensureParsed(cfgPath);
 
-    // Read live system data
-    m_snapshot->refresh();
+  // Read live system data
+  m_snapshot->refresh();
 
-    // Update UI
-    refreshIcon();
-    refreshTooltip();
+  // Update UI
+  refreshIcon();
+  refreshTooltip();
 }
 
 void TrayApp::refreshIcon() {
-    const bool active = m_unit->isActive();
-    if (active) {
-        m_sni->setIconByName(QStringLiteral("security-medium"));
-        m_sni->setStatus(KStatusNotifierItem::Active);
-        m_sni->setTitle(QStringLiteral("nohang, active"));
-    } else {
-        m_sni->setIconByName(QStringLiteral("security-low"));
-        m_sni->setStatus(KStatusNotifierItem::Passive);
-        m_sni->setTitle(QStringLiteral("nohang, inactive"));
-    }
+  const bool active = m_unit->isActive();
+  const QString icon = active ? iconNameFor(*m_cfg, *m_snapshot)
+                              : QStringLiteral("security-low");
+  m_sni->setIconByName(icon);
+  m_sni->setStatus(active ? KStatusNotifierItem::Active
+                          : KStatusNotifierItem::Passive);
+  m_sni->setTitle(active ? QStringLiteral("nohang, active")
+                         : QStringLiteral("nohang, inactive"));
 }
 
 void TrayApp::refreshTooltip() {
-    // Build "configured vs current" text for RAM, swap, zram, PSI
-    const QString tipTitle = QStringLiteral("nohang status");
-    const QString tipIcon  = QStringLiteral("security-medium");
-    const QString tipText  = m_tooltip->build(*m_cfg, *m_snapshot, m_unit->isActive(), m_unit->resolvedConfigPath());
+  // Build "configured vs current" text for RAM, swap, zram, PSI
+  const QString tipTitle = QStringLiteral("nohang status");
+  const QString tipIcon = QStringLiteral("security-medium");
+  const QString tipText = m_tooltip->build(
+      *m_cfg, *m_snapshot, m_unit->isActive(), m_unit->resolvedConfigPath());
 
-    // KStatusNotifierItem tooltips take icon-name, title, subtitle
-    m_sni->setToolTip(tipIcon, tipTitle, tipText);
+  // KStatusNotifierItem tooltips take icon-name, title, subtitle
+  m_sni->setToolTip(tipIcon, tipTitle, tipText);
 }
 
 void TrayApp::onConfigMaybeChanged() {
-    const QString path = m_unit->configPath();
-    if (path.isEmpty()) return;
-    QFileInfo fi(path);
-    if (fi.exists()) {
-        const qint64 mt = fi.lastModified().toSecsSinceEpoch();
-        if (mt != m_configMtimeCache) {
-            m_configMtimeCache = mt;
-            m_cfg->ensureParsed(path);
-            refreshTooltip();
-        }
+  const QString path = m_unit->configPath();
+  if (path.isEmpty())
+    return;
+  QFileInfo fi(path);
+  if (fi.exists()) {
+    const qint64 mt = fi.lastModified().toSecsSinceEpoch();
+    if (mt != m_configMtimeCache) {
+      m_configMtimeCache = mt;
+      m_cfg->ensureParsed(path);
+      refreshTooltip();
     }
+  }
 }

--- a/src/TrayApp.h
+++ b/src/TrayApp.h
@@ -20,38 +20,43 @@ struct ThresholdSet; // from Thresholds.h
 // 4) Builds a concise tooltip that shows "configured vs current"
 // 5) Shows a shield icon when the daemon is active
 class TrayApp : public QObject {
-    Q_OBJECT
+  Q_OBJECT
 public:
-    explicit TrayApp(QObject* parent = nullptr);
-    ~TrayApp();  // out-of-line definition in the .cpp
-    void start();
+  explicit TrayApp(QObject *parent = nullptr);
+  ~TrayApp(); // out-of-line definition in the .cpp
+  void start();
 
-    // Utility method exposed for testing; currently returns the input string
-    // unchanged. Retained for compatibility if tooltips require escaping in
-    // the future.
-    static QString escapePercent(const QString& s);
+  // Utility method exposed for testing; currently returns the input string
+  // unchanged. Retained for compatibility if tooltips require escaping in
+  // the future.
+  static QString escapePercent(const QString &s);
+
+  // Determine icon name based on current thresholds and system snapshot.
+  // This is exposed for testing of severity mapping logic.
+  static QString iconNameFor(const NoHangConfig &cfg,
+                             const SystemSnapshot &snap);
 
 private slots:
-    void tick();              // periodic refresh
-    void refreshIcon();       // sets icon based on active state
-    void refreshTooltip();    // composes tooltip text from models
-    void onConfigMaybeChanged();
+  void tick();           // periodic refresh
+  void refreshIcon();    // sets icon based on active state
+  void refreshTooltip(); // composes tooltip text from models
+  void onConfigMaybeChanged();
 
 private:
-    void setupStatusItem();
-    void setupTimers();
-    void ensureModels();
+  void setupStatusItem();
+  void setupTimers();
+  void ensureModels();
 
-    std::unique_ptr<NoHangUnit>     m_unit;
-    std::unique_ptr<NoHangConfig>   m_cfg;
-    std::unique_ptr<SystemSnapshot> m_snapshot;
-    std::unique_ptr<TooltipBuilder> m_tooltip;
-    std::unique_ptr<ProcessTableAction> m_procAction;
+  std::unique_ptr<NoHangUnit> m_unit;
+  std::unique_ptr<NoHangConfig> m_cfg;
+  std::unique_ptr<SystemSnapshot> m_snapshot;
+  std::unique_ptr<TooltipBuilder> m_tooltip;
+  std::unique_ptr<ProcessTableAction> m_procAction;
 
-    std::unique_ptr<KStatusNotifierItem> m_sni;
-    QTimer* m_pollTimer {nullptr};
-    QTimer* m_cfgWatchTimer {nullptr};
+  std::unique_ptr<KStatusNotifierItem> m_sni;
+  QTimer *m_pollTimer{nullptr};
+  QTimer *m_cfgWatchTimer{nullptr};
 
-    QString m_configPathCache;
-    qint64  m_configMtimeCache {0};
+  QString m_configPathCache;
+  qint64 m_configMtimeCache{0};
 };

--- a/tests/TrayApp_test.cpp
+++ b/tests/TrayApp_test.cpp
@@ -1,10 +1,32 @@
 #include "pch.h"
 #include <gtest/gtest.h>
+#define private public
+#include "NoHangConfig.h"
+#include "SystemSnapshot.h"
+#undef private
 #include "TrayApp.h"
 
-TEST(TrayAppTest, EscapePercent)
-{
-    const QString input = "value 42 %";
-    const QString output = TrayApp::escapePercent(input);
-    EXPECT_EQ(QStringLiteral("value 42 %"), output);
+TEST(TrayAppTest, EscapePercent) {
+  const QString input = "value 42 %";
+  const QString output = TrayApp::escapePercent(input);
+  EXPECT_EQ(QStringLiteral("value 42 %"), output);
+}
+
+TEST(TrayAppTest, IconReflectsMemorySeverity) {
+  NoHangConfig cfg;
+  cfg.m_t.warn_mem_percent = 40.0;
+  cfg.m_t.soft_mem_percent = 30.0;
+  cfg.m_t.hard_mem_percent = 20.0;
+
+  SystemSnapshot snap;
+  snap.m_mem.memTotalMiB = 100.0;
+
+  snap.m_mem.memAvailableMiB = 50.0;
+  EXPECT_EQ(QStringLiteral("security-low"), TrayApp::iconNameFor(cfg, snap));
+
+  snap.m_mem.memAvailableMiB = 35.0;
+  EXPECT_EQ(QStringLiteral("security-medium"), TrayApp::iconNameFor(cfg, snap));
+
+  snap.m_mem.memAvailableMiB = 15.0;
+  EXPECT_EQ(QStringLiteral("security-high"), TrayApp::iconNameFor(cfg, snap));
 }


### PR DESCRIPTION
## Summary
- derive severity from current snapshot and configured thresholds
- map severity to colored shield icons
- document new icon behavior and test icon selection

## Testing
- `cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68b15ed18a5083309cf28f110a418c38