### PR TITLE
Support MiB thresholds and display swap totals

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ cp data/org.archlars.nohangtray.desktop ~/.config/autostart/
 * Hovering the icon shows memory limits from your configuration alongside current usage.
 * This helps you gauge how close you are to running out of memory.
 * Icon color reflects severity: green when resources are plentiful, yellow when warn thresholds are reached, and red for critical conditions.
+* Thresholds in configuration files can be written as percentages (e.g. `10%`) or as absolute MiB values (e.g. `512 MiB`).
 * Robust `/proc/meminfo` parsing tolerates leading whitespace, and `/proc/swaps` totals ensure swap usage is always reported.
 
 ## Technical Details

--- a/src/NoHangConfig.h
+++ b/src/NoHangConfig.h
@@ -37,7 +37,7 @@ public:
 
 private:
     void parseFile(const QString& path);          // simple line parser, ignore comments and @ lines
-    static std::optional<double> parsePercentOrMiB(const QString& raw); // store percent as percent, MiB as absolute MiB
+    static std::optional<double> parsePercentOrMiB(const QString& raw); // percent positive, MiB as negative sentinel
 
     ThresholdsPercent m_t;
     QString m_srcPath;

--- a/src/Thresholds.cpp
+++ b/src/Thresholds.cpp
@@ -2,11 +2,15 @@
 #include "pch.h"
 #include "Thresholds.h"
 
-static ThresholdValue makeVal(std::optional<double> pct, double totalMiB) {
+static ThresholdValue makeVal(std::optional<double> raw, double totalMiB) {
     ThresholdValue v;
-    if (pct) {
-        v.percent = pct;
-        v.mib = totalMiB > 0 ? std::optional<double>(*pct * totalMiB / 100.0) : std::nullopt;
+    if (raw) {
+        if (*raw < 0) {
+            v.mib = -*raw;
+        } else {
+            v.percent = raw;
+            v.mib = totalMiB > 0 ? std::optional<double>(*raw * totalMiB / 100.0) : std::nullopt;
+        }
     }
     return v;
 }

--- a/src/TooltipBuilder.cpp
+++ b/src/TooltipBuilder.cpp
@@ -22,19 +22,33 @@ QString TooltipBuilder::build(const NoHangConfig& cfg,
     s += (active ? "status: active\n" : "status: inactive\n");
     if (!cfgPath.isEmpty()) s += "config: " + cfgPath + "\n";
 
+    auto appendThreshold = [&](const QString& label, const ThresholdValue& tv) {
+        if (tv.percent || tv.mib) {
+            s += label;
+            if (tv.percent) {
+                s += fmtPct(*tv.percent);
+                if (tv.mib) s += QStringLiteral(" (≈ ") + fmtMiB(*tv.mib) + QStringLiteral(")");
+            } else if (tv.mib) {
+                s += fmtMiB(*tv.mib);
+            }
+            s += QStringLiteral("\n");
+        }
+    };
+
     // RAM
     s += "RAM:\n";
     s += "  available: " + fmtMiB(snap.mem().memAvailableMiB) + " (" + fmtPct(snap.mem().memAvailablePercent) + ")\n";
-    if (th.warn_mem_free.percent) s += "  warn if free < " + fmtPct(*th.warn_mem_free.percent) + " (≈ " + (th.warn_mem_free.mib ? fmtMiB(*th.warn_mem_free.mib) : "?") + ")\n";
-    if (th.soft_mem_free.percent) s += "  soft action if free < " + fmtPct(*th.soft_mem_free.percent) + " (≈ " + (th.soft_mem_free.mib ? fmtMiB(*th.soft_mem_free.mib) : "?") + ")\n";
-    if (th.hard_mem_free.percent) s += "  hard action if free < " + fmtPct(*th.hard_mem_free.percent) + " (≈ " + (th.hard_mem_free.mib ? fmtMiB(*th.hard_mem_free.mib) : "?") + ")\n";
+    appendThreshold("  warn if free < ", th.warn_mem_free);
+    appendThreshold("  soft action if free < ", th.soft_mem_free);
+    appendThreshold("  hard action if free < ", th.hard_mem_free);
 
     // Swap
     s += "Swap:\n";
+    s += "  total: " + fmtMiB(snap.mem().swapTotalMiB) + "\n";
     s += "  free: " + fmtMiB(snap.mem().swapFreeMiB) + " (" + fmtPct(snap.mem().swapFreePercent) + ")\n";
-    if (th.warn_swap_free.percent) s += "  warn if free < " + fmtPct(*th.warn_swap_free.percent) + " (≈ " + (th.warn_swap_free.mib ? fmtMiB(*th.warn_swap_free.mib) : "?") + ")\n";
-    if (th.soft_swap_free.percent) s += "  soft action if free < " + fmtPct(*th.soft_swap_free.percent) + " (≈ " + (th.soft_swap_free.mib ? fmtMiB(*th.soft_swap_free.mib) : "?") + ")\n";
-    if (th.hard_swap_free.percent) s += "  hard action if free < " + fmtPct(*th.hard_swap_free.percent) + " (≈ " + (th.hard_swap_free.mib ? fmtMiB(*th.hard_swap_free.mib) : "?") + ")\n";
+    appendThreshold("  warn if free < ", th.warn_swap_free);
+    appendThreshold("  soft action if free < ", th.soft_swap_free);
+    appendThreshold("  hard action if free < ", th.hard_swap_free);
 
     // ZRAM
     if (snap.zram().present) {
@@ -42,9 +56,9 @@ QString TooltipBuilder::build(const NoHangConfig& cfg,
         s += "  size: " + fmtMiB(snap.zram().diskSizeMiB) + "\n";
         s += "  logical used: " + fmtMiB(snap.zram().origDataMiB) + " (" + fmtPct(snap.zram().logicalUsedPercent) + ")\n";
         s += "  physical used: " + fmtMiB(snap.zram().memUsedTotalMiB) + "\n";
-        if (th.warn_zram_used.percent) s += "  warn if used > " + fmtPct(*th.warn_zram_used.percent) + "\n";
-        if (th.soft_zram_used.percent) s += "  soft action if used > " + fmtPct(*th.soft_zram_used.percent) + "\n";
-        if (th.hard_zram_used.percent) s += "  hard action if used > " + fmtPct(*th.hard_zram_used.percent) + "\n";
+        appendThreshold("  warn if used > ", th.warn_zram_used);
+        appendThreshold("  soft action if used > ", th.soft_zram_used);
+        appendThreshold("  hard action if used > ", th.hard_zram_used);
     }
 
     // PSI

--- a/tests/NoHangConfig_test.cpp
+++ b/tests/NoHangConfig_test.cpp
@@ -37,9 +37,9 @@ TEST_F(NoHangConfigTest, ParseMiBValues) {
     cfg.ensureParsed(cfgPath);
     const auto& t = cfg.thresholds();
     ASSERT_TRUE(t.warn_mem_percent.has_value());
-    EXPECT_DOUBLE_EQ(512.0, t.warn_mem_percent.value());
+    EXPECT_DOUBLE_EQ(-512.0, t.warn_mem_percent.value());
     ASSERT_TRUE(t.warn_swap_percent_free.has_value());
-    EXPECT_DOUBLE_EQ(512.0, t.warn_swap_percent_free.value());
+    EXPECT_DOUBLE_EQ(-512.0, t.warn_swap_percent_free.value());
 }
 
 TEST_F(NoHangConfigTest, FallbackToDefaultPaths) {

--- a/tests/Thresholds_test.cpp
+++ b/tests/Thresholds_test.cpp
@@ -78,3 +78,17 @@ TEST(ThresholdsTest, ComputesPercentAndMiB)
     ASSERT_TRUE(out.hard_zram_used.mib.has_value());
     EXPECT_DOUBLE_EQ(450.0, out.hard_zram_used.mib.value());
 }
+
+TEST(ThresholdsTest, HandlesAbsoluteMiBValues)
+{
+    ThresholdsPercent t;
+    t.warn_mem_percent = -100.0; // 100 MiB absolute
+
+    StubSnapshot snap{1000.0, 0.0, 0.0};
+
+    const ThresholdSet out = Thresholds::compute(t, snap);
+
+    EXPECT_FALSE(out.warn_mem_free.percent.has_value());
+    ASSERT_TRUE(out.warn_mem_free.mib.has_value());
+    EXPECT_DOUBLE_EQ(100.0, out.warn_mem_free.mib.value());
+}

--- a/tests/TooltipBuilder_test.cpp
+++ b/tests/TooltipBuilder_test.cpp
@@ -36,7 +36,7 @@ TEST(TooltipBuilderTest, BuildsSummary)
     EXPECT_TRUE(out.contains("status: active"));
     EXPECT_TRUE(out.contains("config: /path.cfg"));
     EXPECT_TRUE(out.contains("warn if free < 10.0 %"));
-    EXPECT_TRUE(out.contains("Swap:\n  free: 500 MiB (50.0 %)\n"));
+    EXPECT_TRUE(out.contains("Swap:\n  total: 1000 MiB\n  free: 500 MiB (50.0 %)\n"));
     EXPECT_TRUE(out.contains("warn if used > 30.0 %"));
     EXPECT_TRUE(out.contains("PSI:"));
     EXPECT_TRUE(out.contains("metric: full_avg10"));

--- a/tests/TrayApp_test.cpp
+++ b/tests/TrayApp_test.cpp
@@ -30,3 +30,19 @@ TEST(TrayAppTest, IconReflectsMemorySeverity) {
   snap.m_mem.memAvailableMiB = 15.0;
   EXPECT_EQ(QStringLiteral("security-high"), TrayApp::iconNameFor(cfg, snap));
 }
+
+TEST(TrayAppTest, IconHandlesMiBThresholds) {
+  NoHangConfig cfg;
+  cfg.m_t.soft_swap_percent_free = -500.0; // 500 MiB soft threshold
+
+  SystemSnapshot snap;
+  snap.m_mem.memTotalMiB = 1000.0;
+  snap.m_mem.memAvailableMiB = 1000.0;
+  snap.m_mem.swapTotalMiB = 1000.0;
+
+  snap.m_mem.swapFreeMiB = 600.0;
+  EXPECT_EQ(QStringLiteral("security-low"), TrayApp::iconNameFor(cfg, snap));
+
+  snap.m_mem.swapFreeMiB = 400.0;
+  EXPECT_EQ(QStringLiteral("security-high"), TrayApp::iconNameFor(cfg, snap));
+}


### PR DESCRIPTION
## Summary
- allow config thresholds written in MiB by encoding them internally and computing correctly
- show swap totals in the tooltip and handle MiB-only thresholds
- document MiB support and add tests for MiB parsing, threshold computation, and icon severity

## Testing
- `./build/NoHangConfig_test`
- `./build/TooltipBuilder_test`
- `./build/Thresholds_test`
- `./build/TrayApp_test`


------
https://chatgpt.com/codex/tasks/task_e_68b18a35049083309b2a41163b1ee491