### PR TITLE
Fallback to meminfo when /proc/swaps is missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ cp data/org.archlars.nohangtray.desktop ~/.config/autostart/
 * This helps you gauge how close you are to running out of memory.
 * Icon color reflects severity: green when resources are plentiful, yellow when warn thresholds are reached, and red for critical conditions.
 * Thresholds in configuration files can be written as percentages (e.g. `10%`) or as absolute MiB values (e.g. `512 MiB`).
-* Robust `/proc/meminfo` parsing tolerates leading whitespace, and `/proc/swaps` totals ensure swap usage is always reported.
+* Robust `/proc/meminfo` parsing tolerates leading whitespace, and `/proc/swaps` totals ensure swap usage is always reported, falling back to `/proc/meminfo` if `/proc/swaps` is empty or unreadable.
 
 ## Technical Details
 

--- a/src/SystemSnapshot.cpp
+++ b/src/SystemSnapshot.cpp
@@ -50,11 +50,15 @@ void SystemSnapshot::readMeminfo() {
 void SystemSnapshot::readSwaps() {
     QFile f(m_procRoot + QStringLiteral("/swaps"));
     if (!f.open(QIODevice::ReadOnly | QIODevice::Text)) {
+        qWarning().noquote() << "SystemSnapshot: cannot open" << f.fileName();
+        if (m_mem.swapTotalMiB == 0 && m_mem.swapFreeMiB == 0) readMeminfo();
         return;
     }
     QTextStream ts(&f);
     QString header;
     if (!ts.readLineInto(&header)) {
+        qWarning().noquote() << "SystemSnapshot: empty" << f.fileName();
+        if (m_mem.swapTotalMiB == 0 && m_mem.swapFreeMiB == 0) readMeminfo();
         return;
     }
     double totalKiB = 0;
@@ -73,6 +77,9 @@ void SystemSnapshot::readSwaps() {
         const double freeKiB = totalKiB - usedKiB;
         m_mem.swapFreeMiB = freeKiB / 1024.0;
         m_mem.swapFreePercent = (m_mem.swapTotalMiB > 0) ? (m_mem.swapFreeMiB * 100.0 / m_mem.swapTotalMiB) : 0;
+    } else {
+        qWarning().noquote() << "SystemSnapshot: empty" << f.fileName();
+        if (m_mem.swapTotalMiB == 0 && m_mem.swapFreeMiB == 0) readMeminfo();
     }
 }
 

--- a/tests/TooltipBuilder_test.cpp
+++ b/tests/TooltipBuilder_test.cpp
@@ -41,3 +41,16 @@ TEST(TooltipBuilderTest, BuildsSummary)
     EXPECT_TRUE(out.contains("PSI:"));
     EXPECT_TRUE(out.contains("metric: full_avg10"));
 }
+
+TEST(TooltipBuilderTest, ShowsSwapSectionWhenUnused)
+{
+    NoHangConfig cfg;
+    SystemSnapshot snap;
+    snap.m_mem.swapTotalMiB = 1000.0;
+    snap.m_mem.swapFreeMiB = 1000.0;
+    snap.m_mem.swapFreePercent = 100.0;
+
+    TooltipBuilder tb;
+    QString out = tb.build(cfg, snap, false, QString());
+    EXPECT_TRUE(out.contains("Swap:\n  total: 1000 MiB\n  free: 1000 MiB (100.0 %)\n"));
+}


### PR DESCRIPTION
## Summary
- warn and use `/proc/meminfo` when `/proc/swaps` is empty or unreadable
- ensure tooltip shows swap section even with zero usage
- document swap fallback logic

## Testing
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68b18e5495dc83308308cdf34c2b4a81