### PR TITLE
Fix threshold handling and tooltip layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ cp data/org.archlars.nohangtray.desktop ~/.config/autostart/
 * The icon appears only when `nohang` is protecting your system.
 * Hovering the icon shows memory limits from your configuration alongside current usage.
 * This helps you gauge how close you are to running out of memory.
-* Icon color reflects severity: green when resources are plentiful, yellow when warn thresholds are reached, and red for critical conditions.
+* Icon color reflects severity: green when resources are plentiful, yellow when warn or soft thresholds are reached, and red for critical conditions.
 * Thresholds in configuration files can be written as percentages (e.g. `10%`) or as absolute MiB values (e.g. `512 MiB`).
 * Robust `/proc/meminfo` parsing tolerates leading whitespace, and `/proc/swaps` totals ensure swap usage is always reported.
 

--- a/src/TooltipBuilder.cpp
+++ b/src/TooltipBuilder.cpp
@@ -38,17 +38,11 @@ QString TooltipBuilder::build(const NoHangConfig& cfg,
     // RAM
     s += "RAM:\n";
     s += "  available: " + fmtMiB(snap.mem().memAvailableMiB) + " (" + fmtPct(snap.mem().memAvailablePercent) + ")\n";
-    appendThreshold("  warn if free < ", th.warn_mem_free);
-    appendThreshold("  soft action if free < ", th.soft_mem_free);
-    appendThreshold("  hard action if free < ", th.hard_mem_free);
 
     // Swap
     s += "Swap:\n";
     s += "  total: " + fmtMiB(snap.mem().swapTotalMiB) + "\n";
     s += "  free: " + fmtMiB(snap.mem().swapFreeMiB) + " (" + fmtPct(snap.mem().swapFreePercent) + ")\n";
-    appendThreshold("  warn if free < ", th.warn_swap_free);
-    appendThreshold("  soft action if free < ", th.soft_swap_free);
-    appendThreshold("  hard action if free < ", th.hard_swap_free);
 
     // ZRAM
     if (snap.zram().present) {
@@ -56,19 +50,33 @@ QString TooltipBuilder::build(const NoHangConfig& cfg,
         s += "  size: " + fmtMiB(snap.zram().diskSizeMiB) + "\n";
         s += "  logical used: " + fmtMiB(snap.zram().origDataMiB) + " (" + fmtPct(snap.zram().logicalUsedPercent) + ")\n";
         s += "  physical used: " + fmtMiB(snap.zram().memUsedTotalMiB) + "\n";
-        appendThreshold("  warn if used > ", th.warn_zram_used);
-        appendThreshold("  soft action if used > ", th.soft_zram_used);
-        appendThreshold("  hard action if used > ", th.hard_zram_used);
     }
 
     // PSI
     s += "PSI:\n";
     s += "  full avg10: " + QString::number(snap.psi().full_avg10, 'f', 2) + ", some avg10: " + QString::number(snap.psi().some_avg10, 'f', 2) + "\n";
     if (!cfg.thresholds().psi_metrics.isEmpty()) s += "  metric: " + cfg.thresholds().psi_metrics + "\n";
-    if (th.warn_psi) s += "  warn if > " + QString::number(*th.warn_psi, 'f', 0) + "\n";
-    if (th.soft_psi) s += "  soft action if > " + QString::number(*th.soft_psi, 'f', 0) + "\n";
-    if (th.hard_psi) s += "  hard action if > " + QString::number(*th.hard_psi, 'f', 0) + "\n";
     if (th.psi_duration) s += "  duration: " + QString::number(*th.psi_duration, 'f', 0) + " s\n";
+
+    // Thresholds after current values
+    s += "Thresholds:\n";
+    appendThreshold("  RAM warn if free < ", th.warn_mem_free);
+    appendThreshold("  RAM soft action if free < ", th.soft_mem_free);
+    appendThreshold("  RAM hard action if free < ", th.hard_mem_free);
+    appendThreshold("  Swap warn if free < ", th.warn_swap_free);
+    appendThreshold("  Swap soft action if free < ", th.soft_swap_free);
+    appendThreshold("  Swap hard action if free < ", th.hard_swap_free);
+    if (snap.zram().present) {
+        appendThreshold("  ZRAM warn if used > ", th.warn_zram_used);
+        appendThreshold("  ZRAM soft action if used > ", th.soft_zram_used);
+        appendThreshold("  ZRAM hard action if used > ", th.hard_zram_used);
+    }
+    if (th.warn_psi)
+        s += "  PSI warn if > " + QString::number(*th.warn_psi, 'f', 0) + "\n";
+    if (th.soft_psi)
+        s += "  PSI soft action if > " + QString::number(*th.soft_psi, 'f', 0) + "\n";
+    if (th.hard_psi)
+        s += "  PSI hard action if > " + QString::number(*th.hard_psi, 'f', 0) + "\n";
 
     // Short hint on actions
     s += "Actions:\n";

--- a/src/TrayApp.cpp
+++ b/src/TrayApp.cpp
@@ -41,21 +41,21 @@ QString TrayApp::iconNameFor(const NoHangConfig &cfg,
 
   const bool critical =
       below(snap.mem().memAvailableMiB, th.hard_mem_free.mib) ||
-      below(snap.mem().memAvailableMiB, th.soft_mem_free.mib) ||
       below(snap.mem().swapFreeMiB, th.hard_swap_free.mib) ||
-      below(snap.mem().swapFreeMiB, th.soft_swap_free.mib) ||
       above(snap.zram().origDataMiB, th.hard_zram_used.mib) ||
-      above(snap.zram().origDataMiB, th.soft_zram_used.mib) ||
-      (th.hard_psi && psiVal > *th.hard_psi) ||
-      (th.soft_psi && psiVal > *th.soft_psi);
+      (th.hard_psi && psiVal > *th.hard_psi);
 
   if (critical)
     return QStringLiteral("security-high");
 
   const bool warning =
+      below(snap.mem().memAvailableMiB, th.soft_mem_free.mib) ||
       below(snap.mem().memAvailableMiB, th.warn_mem_free.mib) ||
+      below(snap.mem().swapFreeMiB, th.soft_swap_free.mib) ||
       below(snap.mem().swapFreeMiB, th.warn_swap_free.mib) ||
+      above(snap.zram().origDataMiB, th.soft_zram_used.mib) ||
       above(snap.zram().origDataMiB, th.warn_zram_used.mib) ||
+      (th.soft_psi && psiVal > *th.soft_psi) ||
       (th.warn_psi && psiVal > *th.warn_psi);
 
   if (warning)

--- a/tests/TooltipBuilder_test.cpp
+++ b/tests/TooltipBuilder_test.cpp
@@ -35,9 +35,16 @@ TEST(TooltipBuilderTest, BuildsSummary)
     QString out = tb.build(cfg, snap, true, "/path.cfg");
     EXPECT_TRUE(out.contains("status: active"));
     EXPECT_TRUE(out.contains("config: /path.cfg"));
-    EXPECT_TRUE(out.contains("warn if free < 10.0 %"));
-    EXPECT_TRUE(out.contains("Swap:\n  total: 1000 MiB\n  free: 500 MiB (50.0 %)\n"));
-    EXPECT_TRUE(out.contains("warn if used > 30.0 %"));
+
+    const int swapPos = out.indexOf("Swap:\n  total: 1000 MiB\n  free: 500 MiB (50.0 %)\n");
+    const int threshPos = out.indexOf("Thresholds:\n");
+    EXPECT_NE(-1, swapPos);
+    EXPECT_NE(-1, threshPos);
+    EXPECT_LT(swapPos, threshPos);
+
+    EXPECT_TRUE(out.contains("Thresholds:\n"));
+    EXPECT_TRUE(out.contains("RAM warn if free < 10.0 %"));
+    EXPECT_TRUE(out.contains("ZRAM warn if used > 30.0 %"));
     EXPECT_TRUE(out.contains("PSI:"));
     EXPECT_TRUE(out.contains("metric: full_avg10"));
 }

--- a/tests/TrayApp_test.cpp
+++ b/tests/TrayApp_test.cpp
@@ -27,6 +27,9 @@ TEST(TrayAppTest, IconReflectsMemorySeverity) {
   snap.m_mem.memAvailableMiB = 35.0;
   EXPECT_EQ(QStringLiteral("security-medium"), TrayApp::iconNameFor(cfg, snap));
 
+  snap.m_mem.memAvailableMiB = 25.0;
+  EXPECT_EQ(QStringLiteral("security-medium"), TrayApp::iconNameFor(cfg, snap));
+
   snap.m_mem.memAvailableMiB = 15.0;
   EXPECT_EQ(QStringLiteral("security-high"), TrayApp::iconNameFor(cfg, snap));
 }
@@ -44,5 +47,5 @@ TEST(TrayAppTest, IconHandlesMiBThresholds) {
   EXPECT_EQ(QStringLiteral("security-low"), TrayApp::iconNameFor(cfg, snap));
 
   snap.m_mem.swapFreeMiB = 400.0;
-  EXPECT_EQ(QStringLiteral("security-high"), TrayApp::iconNameFor(cfg, snap));
+  EXPECT_EQ(QStringLiteral("security-medium"), TrayApp::iconNameFor(cfg, snap));
 }


### PR DESCRIPTION
## Summary
- prevent soft thresholds from triggering critical icon
- show current RAM, swap, and PSI stats before thresholds to avoid tooltip truncation
- document icon color behavior for warn/soft thresholds

## Testing
- `ctest --test-dir build`

------
https://chatgpt.com/codex/tasks/task_e_68b20a9dbff48330a7963c8177cabbee