### PR TITLE
test: expand tray logic coverage

### DIFF
--- a/tests/TooltipBuilder_test.cpp
+++ b/tests/TooltipBuilder_test.cpp
@@ -48,3 +48,61 @@ TEST(TooltipBuilderTest, BuildsSummary)
     EXPECT_TRUE(out.contains("PSI:"));
     EXPECT_TRUE(out.contains("metric: full_avg10"));
 }
+
+TEST(TooltipBuilderTest, IncludesAllSections)
+{
+    NoHangConfig cfg;
+    cfg.m_t.warn_mem_percent = 10.0;
+    cfg.m_t.soft_mem_percent = 5.0;
+    cfg.m_t.hard_mem_percent = 1.0;
+    cfg.m_t.warn_swap_percent_free = 20.0;
+    cfg.m_t.soft_swap_percent_free = 15.0;
+    cfg.m_t.hard_swap_percent_free = 5.0;
+    cfg.m_t.warn_zram_percent_used = 30.0;
+    cfg.m_t.soft_zram_percent_used = 40.0;
+    cfg.m_t.hard_zram_percent_used = 50.0;
+    cfg.m_t.warn_psi = 10.0;
+    cfg.m_t.soft_psi = 20.0;
+    cfg.m_t.hard_psi = 30.0;
+    cfg.m_t.psi_metrics = "some";
+    cfg.m_t.psi_duration = 60.0;
+
+    SystemSnapshot snap;
+    snap.m_mem.memAvailableMiB = 800.0;
+    snap.m_mem.memTotalMiB = 1000.0;
+    snap.m_mem.memAvailablePercent = 80.0;
+    snap.m_mem.swapFreeMiB = 200.0;
+    snap.m_mem.swapTotalMiB = 400.0;
+    snap.m_mem.swapFreePercent = 50.0;
+    snap.m_zram.present = true;
+    snap.m_zram.diskSizeMiB = 100.0;
+    snap.m_zram.origDataMiB = 10.0;
+    snap.m_zram.memUsedTotalMiB = 5.0;
+    snap.m_zram.logicalUsedPercent = 10.0;
+    snap.m_psi.some_avg10 = 1.2;
+    snap.m_psi.full_avg10 = 0.3;
+
+    TooltipBuilder tb;
+    const QString out = tb.build(cfg, snap, true, "/etc/nohang.cfg");
+    EXPECT_NE(-1, out.indexOf("RAM:\n"));
+    EXPECT_NE(-1, out.indexOf("Swap:\n"));
+    EXPECT_NE(-1, out.indexOf("ZRAM:\n"));
+    EXPECT_NE(-1, out.indexOf("PSI:\n"));
+    EXPECT_NE(-1, out.indexOf("Thresholds:\n"));
+    EXPECT_NE(-1, out.indexOf("Actions:\n"));
+    EXPECT_TRUE(out.contains("RAM hard action if free <"));
+    EXPECT_TRUE(out.contains("Swap hard action if free <"));
+    EXPECT_TRUE(out.contains("ZRAM hard action if used >"));
+    EXPECT_TRUE(out.contains("PSI hard action if >"));
+}
+
+TEST(TooltipBuilderTest, OmitsZramSectionWhenAbsent)
+{
+    NoHangConfig cfg;
+    SystemSnapshot snap;
+    snap.m_zram.present = false;
+
+    TooltipBuilder tb;
+    const QString out = tb.build(cfg, snap, false, QString());
+    EXPECT_EQ(-1, out.indexOf("ZRAM:"));
+}

--- a/tests/TrayApp_test.cpp
+++ b/tests/TrayApp_test.cpp
@@ -49,3 +49,72 @@ TEST(TrayAppTest, IconHandlesMiBThresholds) {
   snap.m_mem.swapFreeMiB = 400.0;
   EXPECT_EQ(QStringLiteral("security-medium"), TrayApp::iconNameFor(cfg, snap));
 }
+
+TEST(TrayAppTest, IconBoundaryAtWarnThreshold) {
+  NoHangConfig cfg;
+  cfg.m_t.warn_mem_percent = 10.0;
+
+  SystemSnapshot snap;
+  snap.m_mem.memTotalMiB = 1000.0;
+
+  snap.m_mem.memAvailableMiB = 100.0; // exactly at threshold
+  EXPECT_EQ(QStringLiteral("security-low"), TrayApp::iconNameFor(cfg, snap));
+
+  snap.m_mem.memAvailableMiB = 99.9; // just below
+  EXPECT_EQ(QStringLiteral("security-medium"), TrayApp::iconNameFor(cfg, snap));
+
+  snap.m_mem.memAvailableMiB = 100.1; // just above
+  EXPECT_EQ(QStringLiteral("security-low"), TrayApp::iconNameFor(cfg, snap));
+}
+
+TEST(TrayAppTest, IconThresholdPrecedence) {
+  NoHangConfig cfg;
+  cfg.m_t.warn_mem_percent = 80.0;
+  cfg.m_t.soft_mem_percent = 70.0;
+  cfg.m_t.hard_mem_percent = 60.0;
+
+  SystemSnapshot snap;
+  snap.m_mem.memTotalMiB = 100.0;
+
+  snap.m_mem.memAvailableMiB = 75.0; // warn only
+  EXPECT_EQ(QStringLiteral("security-medium"), TrayApp::iconNameFor(cfg, snap));
+
+  snap.m_mem.memAvailableMiB = 65.0; // warn + soft
+  EXPECT_EQ(QStringLiteral("security-medium"), TrayApp::iconNameFor(cfg, snap));
+
+  snap.m_mem.memAvailableMiB = 55.0; // hard
+  EXPECT_EQ(QStringLiteral("security-high"), TrayApp::iconNameFor(cfg, snap));
+}
+
+TEST(TrayAppTest, IconIgnoresMissingSwapAndZram) {
+  NoHangConfig cfg;
+  cfg.m_t.warn_swap_percent_free = 10.0;
+  cfg.m_t.warn_zram_percent_used = 50.0;
+
+  SystemSnapshot snap;
+  snap.m_mem.memTotalMiB = 1000.0;
+  snap.m_mem.memAvailableMiB = 1000.0;
+  snap.m_mem.swapTotalMiB = 0.0; // no swap configured
+  snap.m_mem.swapFreeMiB = 0.0;
+  snap.m_zram.present = false;    // zram not available
+
+  EXPECT_EQ(QStringLiteral("security-low"), TrayApp::iconNameFor(cfg, snap));
+}
+
+TEST(TrayAppTest, IconUsesPsiMetric) {
+  NoHangConfig cfg;
+  cfg.m_t.warn_psi = 10.0;
+  cfg.m_t.hard_psi = 20.0;
+  cfg.m_t.psi_metrics = QStringLiteral("some");
+
+  SystemSnapshot snap;
+  snap.m_psi.some_avg10 = 25.0; // above hard
+  snap.m_psi.full_avg10 = 5.0;
+  EXPECT_EQ(QStringLiteral("security-high"), TrayApp::iconNameFor(cfg, snap));
+
+  snap.m_psi.some_avg10 = 15.0; // between warn and hard
+  EXPECT_EQ(QStringLiteral("security-medium"), TrayApp::iconNameFor(cfg, snap));
+
+  snap.m_psi.some_avg10 = 5.0; // below warn
+  EXPECT_EQ(QStringLiteral("security-low"), TrayApp::iconNameFor(cfg, snap));
+}


### PR DESCRIPTION
## Summary
- add boundary, precedence, missing-data, and PSI metric tests for `TrayApp::iconNameFor`
- verify tooltip builder covers all sections and omits ZRAM when absent

## Testing
- `QT_QPA_PLATFORM=offscreen ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68b20cbf22f48330b1b9891b1a9e1e69