### PR TITLE
ci: enable bash tracing in Debian build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,9 @@ jobs:
   build-debian-trixie:
     runs-on: ubuntu-latest
     container: debian:trixie-slim
+    defaults:
+      run:
+        shell: bash -eux {0}
     env:
       DEBIAN_FRONTEND: noninteractive
       CCACHE_DIR: /ccache


### PR DESCRIPTION
## Summary
- run debian build job steps under `bash -eux {0}` for better logging and safety

## Testing
- `yamllint .github/workflows/ci.yml` *(fails: missing document start, truthy, spacing, line length, empty-lines)*
- `cmake -S . -B build -DBUILD_TESTING=OFF`
- `cmake --build build`

------
https://chatgpt.com/codex/tasks/task_e_68b20f907dc08330bf942380c702c615