### PR TITLE
ci: keep builds alive with verbose output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ concurrency:
 jobs:
   build-debian-trixie:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     container: debian:trixie-slim
     defaults:
       run:
@@ -60,10 +61,14 @@ jobs:
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
 
       - name: Build
-        run: cmake --build build -j
+        run: |
+          (while sleep 60; do echo "still building..."; done) &
+          KEEP_ALIVE=$!
+          trap "kill $KEEP_ALIVE" EXIT
+          cmake --build build -j -- -v
 
       - name: Test
-        run: ctest --test-dir build --output-on-failure
+        run: ctest --test-dir build --progress --output-on-failure
 
       - name: Coverage
         run: |

--- a/README.md
+++ b/README.md
@@ -11,9 +11,11 @@
    ```
 2. Generate the build directory and compile:
    ```bash
-   cmake -G Ninja -S . -B build -DCMAKE_BUILD_TYPE=Release
-   cmake --build build -j$(nproc)
-   ```
+    cmake -G Ninja -S . -B build -DCMAKE_BUILD_TYPE=Release
+    cmake --build build -j$(nproc) -- -v
+    ```
+    The `-- -v` flag forwards `-v` to Ninja so each command is logged,
+    which helps keep CI and local builds from appearing idle.
 
 ### Other distributions
 - **Debian/Ubuntu**
@@ -29,7 +31,7 @@ After installing dependencies, generate the build directory and compile:
 
 ```bash
 cmake -G Ninja -S . -B build -DCMAKE_BUILD_TYPE=Release
-cmake --build build -j$(nproc)
+cmake --build build -j$(nproc) -- -v
 ```
 
 ## Usage


### PR DESCRIPTION
## Summary
- emit periodic output during Ninja builds and show per-test progress to avoid CI timeouts
- document verbose `cmake --build` usage in README

## Testing
- `cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug`
- `cmake --build build -j 4`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68b211a3c6908330b43854f2a4dd5c94