### PR TITLE
Ensure process table dialog deleted on close

### DIFF
--- a/src/ProcessTableAction.cpp
+++ b/src/ProcessTableAction.cpp
@@ -27,6 +27,7 @@ void ProcessTableAction::runTasks() {
     p.waitForFinished(3000);
 
     auto dlg = new QDialog();
+    dlg->setAttribute(Qt::WA_DeleteOnClose);
     dlg->setWindowTitle(QStringLiteral("nohang --tasks"));
     auto* edit = new QTextEdit(dlg);
     edit->setReadOnly(true);

--- a/tests/ProcessTableAction_test.cpp
+++ b/tests/ProcessTableAction_test.cpp
@@ -43,9 +43,13 @@ TEST(ProcessTableActionTest, RunTasksDisplaysOutput)
     qputenv("QT_QPA_PLATFORM", QByteArray("offscreen"));
     QApplication app(argc, argv);
 
+    int before = QApplication::topLevelWidgets().size();
+
     ProcessTableAction act;
     act.runTasks();
     QApplication::processEvents();
+
+    EXPECT_EQ(before + 1, QApplication::topLevelWidgets().size());
 
     bool found = false;
     for (QWidget* w : QApplication::topLevelWidgets()) {
@@ -60,4 +64,7 @@ TEST(ProcessTableActionTest, RunTasksDisplaysOutput)
         }
     }
     EXPECT_TRUE(found);
+
+    QApplication::processEvents();
+    EXPECT_EQ(before, QApplication::topLevelWidgets().size());
 }


### PR DESCRIPTION
## Summary
- delete ProcessTableAction's dialog when closed via Qt::WA_DeleteOnClose
- test dialog cleanup by counting top-level widgets before and after runTasks

## Testing
- `ctest --test-dir build --progress`


------
https://chatgpt.com/codex/tasks/task_e_68b2152570108330b364c159f7249a61