### PR TITLE
Ensure NoHangUnit config path can refresh

### DIFF
--- a/src/NoHangUnit.cpp
+++ b/src/NoHangUnit.cpp
@@ -16,15 +16,16 @@ bool NoHangUnit::isActive() const {
     return p.exitStatus() == QProcess::NormalExit && p.exitCode() == 0;
 }
 
-QString NoHangUnit::configPath() const {
-    if (!m_haveCached) {
-        const auto exec = readExecStart();
+QString NoHangUnit::configPath(bool refresh) const {
+    const auto exec = readExecStart();
+    if (refresh || !m_haveCached || exec != m_lastExecStart) {
         m_cachedConfig = parseConfigFromExec(exec);
         if (m_cachedConfig.isEmpty()) {
             // Fallbacks, first etc, then distro defaults
             m_cachedConfig = QStringLiteral("/etc/nohang/nohang-desktop.conf");
         }
         m_haveCached = true;
+        m_lastExecStart = exec;
     }
     return m_cachedConfig;
 }

--- a/src/NoHangUnit.h
+++ b/src/NoHangUnit.h
@@ -10,14 +10,16 @@ class NoHangUnit : public QObject {
 public:
     explicit NoHangUnit(QObject* parent = nullptr);
 
-    bool isActive() const;                 // systemctl is-active nohang-desktop.service
-    QString configPath() const;            // parse ExecStart for --config
-    QString resolvedConfigPath() const;    // cached, or fallback to defaults
+    bool isActive() const;                           // systemctl is-active nohang-desktop.service
+    QString configPath(bool refresh = false) const;  // parse ExecStart for --config
+    QString resolvedConfigPath() const;              // cached, or fallback to defaults
 
-private:
-    QString readExecStart() const;
+protected:
+    virtual QString readExecStart() const;
     QString parseConfigFromExec(const QString& execStart) const;
 
+private:
     mutable QString m_cachedConfig;
     mutable bool m_haveCached {false};
+    mutable QString m_lastExecStart;
 };

--- a/tests/NoHangUnit_test.cpp
+++ b/tests/NoHangUnit_test.cpp
@@ -1,8 +1,10 @@
 #include "pch.h"
 #include <gtest/gtest.h>
+#define protected public
 #define private public
 #include "NoHangUnit.h"
 #undef private
+#undef protected
 
 TEST(NoHangUnitTest, ParseConfigFromExec)
 {
@@ -18,4 +20,22 @@ TEST(NoHangUnitTest, FallbacksWhenUnitAbsent)
     QString path = unit.configPath();
     EXPECT_EQ("/etc/nohang/nohang-desktop.conf", path);
     EXPECT_EQ(path, unit.resolvedConfigPath());
+}
+
+TEST(NoHangUnitTest, ConfigPathRefreshesWhenExecChanges)
+{
+    struct MockUnit : public NoHangUnit {
+        QString exec;
+        QString readExecStart() const override { return exec; }
+    };
+
+    MockUnit unit;
+    unit.exec = "ExecStart={ path=/usr/bin/nohang ; argv[]=/usr/bin/nohang --monitor --config /etc/nohang/first.conf ; }";
+    EXPECT_EQ("/etc/nohang/first.conf", unit.configPath());
+
+    unit.exec = "ExecStart={ path=/usr/bin/nohang ; argv[]=/usr/bin/nohang --monitor --config /etc/nohang/second.conf ; }";
+    EXPECT_EQ("/etc/nohang/second.conf", unit.configPath());
+
+    unit.exec = "ExecStart={ path=/usr/bin/nohang ; argv[]=/usr/bin/nohang --monitor --config /etc/nohang/third.conf ; }";
+    EXPECT_EQ("/etc/nohang/third.conf", unit.configPath(true));
 }


### PR DESCRIPTION
## Summary
- allow forcing config path refresh and detect ExecStart changes
- validate new behavior with tests

## Testing
- `ctest --test-dir build --progress`


------
https://chatgpt.com/codex/tasks/task_e_68b21524c81083308727dcf56d0b6312