### PR TITLE
Condense tooltip summary to fit Plasma limit

### DIFF
--- a/src/TooltipBuilder.cpp
+++ b/src/TooltipBuilder.cpp
@@ -36,27 +36,21 @@ QString TooltipBuilder::build(const NoHangConfig& cfg,
     };
 
     // RAM
-    s += "RAM:\n";
-    s += "  available: " + fmtMiB(snap.mem().memAvailableMiB) + " (" + fmtPct(snap.mem().memAvailablePercent) + ")\n";
+    s += "RAM: available " + fmtMiB(snap.mem().memAvailableMiB) + " (" + fmtPct(snap.mem().memAvailablePercent) + ")\n";
 
     // Swap
-    s += "Swap:\n";
-    s += "  total: " + fmtMiB(snap.mem().swapTotalMiB) + "\n";
-    s += "  free: " + fmtMiB(snap.mem().swapFreeMiB) + " (" + fmtPct(snap.mem().swapFreePercent) + ")\n";
+    s += "Swap: total " + fmtMiB(snap.mem().swapTotalMiB) + ", free " + fmtMiB(snap.mem().swapFreeMiB) + " (" + fmtPct(snap.mem().swapFreePercent) + ")\n";
 
     // ZRAM
     if (snap.zram().present) {
-        s += "ZRAM:\n";
-        s += "  size: " + fmtMiB(snap.zram().diskSizeMiB) + "\n";
-        s += "  logical used: " + fmtMiB(snap.zram().origDataMiB) + " (" + fmtPct(snap.zram().logicalUsedPercent) + ")\n";
-        s += "  physical used: " + fmtMiB(snap.zram().memUsedTotalMiB) + "\n";
+        s += "ZRAM: size " + fmtMiB(snap.zram().diskSizeMiB) + ", logical used " + fmtMiB(snap.zram().origDataMiB) + " (" + fmtPct(snap.zram().logicalUsedPercent) + "), physical used " + fmtMiB(snap.zram().memUsedTotalMiB) + "\n";
     }
 
     // PSI
-    s += "PSI:\n";
-    s += "  full avg10: " + QString::number(snap.psi().full_avg10, 'f', 2) + ", some avg10: " + QString::number(snap.psi().some_avg10, 'f', 2) + "\n";
-    if (!cfg.thresholds().psi_metrics.isEmpty()) s += "  metric: " + cfg.thresholds().psi_metrics + "\n";
-    if (th.psi_duration) s += "  duration: " + QString::number(*th.psi_duration, 'f', 0) + " s\n";
+    s += "PSI: full avg10 " + QString::number(snap.psi().full_avg10, 'f', 2) + ", some avg10 " + QString::number(snap.psi().some_avg10, 'f', 2);
+    if (!cfg.thresholds().psi_metrics.isEmpty()) s += ", metric " + cfg.thresholds().psi_metrics;
+    if (th.psi_duration) s += ", duration " + QString::number(*th.psi_duration, 'f', 0) + " s";
+    s += "\n";
 
     // Thresholds after current values
     s += "Thresholds:\n";
@@ -77,10 +71,6 @@ QString TooltipBuilder::build(const NoHangConfig& cfg,
         s += "  PSI soft action if > " + QString::number(*th.soft_psi, 'f', 0) + "\n";
     if (th.hard_psi)
         s += "  PSI hard action if > " + QString::number(*th.hard_psi, 'f', 0) + "\n";
-
-    // Short hint on actions
-    s += "Actions:\n";
-    s += "  soft: ask a target to exit cleanly, hard: force kill if pressure persists.\n";
 
     return s;
 }

--- a/tests/TooltipBuilder_test.cpp
+++ b/tests/TooltipBuilder_test.cpp
@@ -36,17 +36,16 @@ TEST(TooltipBuilderTest, BuildsSummary)
     EXPECT_TRUE(out.contains("status: active"));
     EXPECT_TRUE(out.contains("config: /path.cfg"));
 
-    const int swapPos = out.indexOf("Swap:\n  total: 1000 MiB\n  free: 500 MiB (50.0 %)\n");
-    const int threshPos = out.indexOf("Thresholds:\n");
-    EXPECT_NE(-1, swapPos);
-    EXPECT_NE(-1, threshPos);
-    EXPECT_LT(swapPos, threshPos);
+    EXPECT_TRUE(out.contains("RAM: available 1000 MiB (50.0 %)"));
+    EXPECT_TRUE(out.contains("Swap: total 1000 MiB, free 500 MiB (50.0 %)"));
+    EXPECT_TRUE(out.contains("ZRAM: size 100 MiB, logical used 50 MiB (50.0 %), physical used 10 MiB"));
+    EXPECT_TRUE(out.contains("PSI: full avg10 0.30, some avg10 1.20, metric full_avg10, duration 60 s"));
 
     EXPECT_TRUE(out.contains("Thresholds:\n"));
     EXPECT_TRUE(out.contains("RAM warn if free < 10.0 %"));
     EXPECT_TRUE(out.contains("ZRAM warn if used > 30.0 %"));
-    EXPECT_TRUE(out.contains("PSI:"));
-    EXPECT_TRUE(out.contains("metric: full_avg10"));
+    EXPECT_TRUE(out.contains("PSI warn if > 50"));
+    EXPECT_EQ(-1, out.indexOf("Actions:"));
 }
 
 TEST(TooltipBuilderTest, IncludesAllSections)
@@ -84,12 +83,12 @@ TEST(TooltipBuilderTest, IncludesAllSections)
 
     TooltipBuilder tb;
     const QString out = tb.build(cfg, snap, true, "/etc/nohang.cfg");
-    EXPECT_NE(-1, out.indexOf("RAM:\n"));
-    EXPECT_NE(-1, out.indexOf("Swap:\n"));
-    EXPECT_NE(-1, out.indexOf("ZRAM:\n"));
-    EXPECT_NE(-1, out.indexOf("PSI:\n"));
+    EXPECT_NE(-1, out.indexOf("RAM:"));
+    EXPECT_NE(-1, out.indexOf("Swap:"));
+    EXPECT_NE(-1, out.indexOf("ZRAM:"));
+    EXPECT_NE(-1, out.indexOf("PSI:"));
     EXPECT_NE(-1, out.indexOf("Thresholds:\n"));
-    EXPECT_NE(-1, out.indexOf("Actions:\n"));
+    EXPECT_EQ(-1, out.indexOf("Actions:"));
     EXPECT_TRUE(out.contains("RAM hard action if free <"));
     EXPECT_TRUE(out.contains("Swap hard action if free <"));
     EXPECT_TRUE(out.contains("ZRAM hard action if used >"));


### PR DESCRIPTION
## Summary
- Collapse RAM, Swap, ZRAM, and PSI sections into single-line summaries
- Drop verbose Actions block to keep the tooltip concise
- Update TooltipBuilder tests for new format and ensure ZRAM data remains visible

## Testing
- `cmake --build build -v`
- `ctest --test-dir build --progress`
- `/tmp/tooltip_demo`


------
https://chatgpt.com/codex/tasks/task_e_68b21959e0c4833092b8bd41fc7d640a