### PR TITLE
Disable zero thresholds in TrayApp

### DIFF
--- a/src/NoHangConfig.cpp
+++ b/src/NoHangConfig.cpp
@@ -46,7 +46,8 @@ void NoHangConfig::parseFile(const QString& path) {
                 const int eq = line.indexOf('=');
                 if (eq > 0) {
                     const QString raw = line.mid(eq + 1).trimmed();
-                    slot = parsePercentOrMiB(raw);
+                    auto val = parsePercentOrMiB(raw);
+                    if (val || raw == QStringLiteral("0")) slot = val; // preserve zero values
                 }
             }
         };

--- a/src/Thresholds.cpp
+++ b/src/Thresholds.cpp
@@ -4,7 +4,7 @@
 
 static ThresholdValue makeVal(std::optional<double> raw, double totalMiB) {
     ThresholdValue v;
-    if (raw) {
+    if (raw && *raw != 0) {
         if (*raw < 0) {
             v.mib = -*raw;
         } else {
@@ -22,17 +22,17 @@ ThresholdSet Thresholds::compute(const ThresholdsPercent& t, const SystemSnapsho
     out.warn_swap_free = makeVal(t.warn_swap_percent_free, snap.mem().swapTotalMiB);
     // ZRAM thresholds are used percent of logical disksize
     out.warn_zram_used = makeVal(t.warn_zram_percent_used, snap.zram().diskSizeMiB);
-    out.warn_psi       = t.warn_psi;
+    out.warn_psi       = (t.warn_psi && *t.warn_psi != 0) ? t.warn_psi : std::nullopt;
 
     out.soft_mem_free  = makeVal(t.soft_mem_percent,  snap.mem().memTotalMiB);
     out.soft_swap_free = makeVal(t.soft_swap_percent_free, snap.mem().swapTotalMiB);
     out.soft_zram_used = makeVal(t.soft_zram_percent_used, snap.zram().diskSizeMiB);
-    out.soft_psi       = t.soft_psi;
+    out.soft_psi       = (t.soft_psi && *t.soft_psi != 0) ? t.soft_psi : std::nullopt;
 
     out.hard_mem_free  = makeVal(t.hard_mem_percent,  snap.mem().memTotalMiB);
     out.hard_swap_free = makeVal(t.hard_swap_percent_free, snap.mem().swapTotalMiB);
     out.hard_zram_used = makeVal(t.hard_zram_percent_used, snap.zram().diskSizeMiB);
-    out.hard_psi       = t.hard_psi;
+    out.hard_psi       = (t.hard_psi && *t.hard_psi != 0) ? t.hard_psi : std::nullopt;
 
     out.psi_metrics    = t.psi_metrics;
     out.psi_duration   = t.psi_duration;

--- a/tests/TrayApp_test.cpp
+++ b/tests/TrayApp_test.cpp
@@ -147,3 +147,17 @@ TEST(TrayAppTest, IconPsiMetricIgnoresPartialMatch) {
   snap.m_psi.full_avg10 = 5.0;  // below warn
   EXPECT_EQ(QStringLiteral("security-low"), TrayApp::iconNameFor(cfg, snap));
 }
+
+TEST(TrayAppTest, IconIgnoresZeroZramThresholds) {
+  NoHangConfig cfg;
+  cfg.m_t.warn_zram_percent_used = 0.0;
+  cfg.m_t.soft_zram_percent_used = 0.0;
+  cfg.m_t.hard_zram_percent_used = 0.0;
+
+  SystemSnapshot snap;
+  snap.m_zram.present = true;
+  snap.m_zram.diskSizeMiB = 100.0;
+  snap.m_zram.origDataMiB = 80.0;
+
+  EXPECT_EQ(QStringLiteral("security-low"), TrayApp::iconNameFor(cfg, snap));
+}


### PR DESCRIPTION
## Summary
- Treat threshold value 0 as disabled in `Thresholds::compute` and PSI thresholds
- Preserve zero values when parsing config so thresholds can ignore them
- Add regression test ensuring ZRAM thresholds of zero keep icon at low severity

## Testing
- `cmake --build build -j -- VERBOSE=1`
- `ctest --test-dir build --progress --output-on-failure -V`


------
https://chatgpt.com/codex/tasks/task_e_68b21b1d8058833085e39ac0a15d7dd5